### PR TITLE
Add keyboard shortcut to open and close editor.

### DIFF
--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -269,7 +269,7 @@
 
 				var isCtrl = false, // Status of control/command key
 					isShift = false, // Status of shift key
-					modifier = navigator.appVersion.indexOf( 'Mac' ) !== -1 ? 91 : 17, // use command (91) for Mac
+					modifier = navigator.appVersion.indexOf( 'Mac' ) !== -1 ? 91 : 17, // Use command (91) for Mac
 					customizePostShortcuts = customizePostShortcuts || {};
 
 				customizePostShortcuts.keysUp = function( e ) {

--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -142,6 +142,9 @@
 		addContentControl: function() {
 			var section = this, control, setting = api( section.id ), editor;
 
+			// Get shortcut label for Mac or PC
+			var shortcutLabel = navigator.appVersion.indexOf( 'Mac' ) !== - 1 ? api.Posts.data.l10n.keyboardToggle.mac : api.Posts.data.l10n.keyboardToggle.pc;
+
 			control = new api.controlConstructor.dynamic( section.id + '[post_content]', {
 				params: {
 					section: section.id,
@@ -157,6 +160,8 @@
 			} );
 			control.editorExpanded = new api.Value( false );
 			control.editorToggleExpandButton = $( '<button type="button" class="button"></button>' );
+			/** Create container for shortcut key display */
+			control.editorToggleExpandButtonShortcut = $( '<div style="display: inline-block; padding: 5px;">' + shortcutLabel + '</div>' );
 			control.updateEditorToggleExpandButtonLabel = function( expanded ) {
 				control.editorToggleExpandButton.text( expanded ? api.Posts.data.l10n.closeEditor : api.Posts.data.l10n.openEditor );
 			};
@@ -227,9 +232,21 @@
 			section.expanded.bind( function( expanded ) {
 				if ( expanded ) {
 					api.Posts.postIdInput.val( section.params.post_id );
+
+					/** Respond to Crtl/Cmnd+Shift+E */
+					$( document ).on('customizePostCtrlShiftE', function() {
+						control.editorExpanded.set( ! control.editorExpanded() );
+						if ( control.editorExpanded() ) {
+							editor.focus();
+						}
+					});
+
 				} else {
 					api.Posts.postIdInput.val( '' );
 					control.editorExpanded.set( false );
+
+					/** Remove Ctrl/Cmd+Shift+E trigger handler. */
+					$( document ).off('customizePostCtrlShiftE');
 				}
 			} );
 
@@ -242,6 +259,46 @@
 					editor.focus();
 				}
 			} );
+
+
+			/**
+			 * Create Ctrl/Cmnd+Shift+E shortcut trigger.
+			 * This adds the `customizePostCtrlShiftE` trigger to the document.
+			 */
+			(function(){
+
+				var isCtrl = false, // status of control/command key
+					isShift = false, // status of shift key
+					modifier = navigator.appVersion.indexOf( 'Mac' ) !== - 1 ? 91 : 17, // use command (91) for Mac
+					customizePostShortcuts = customizePostShortcuts || {};
+
+				customizePostShortcuts.keysUp = function( e ) {
+					isShift = e.which === 16 ? false : isCtrl;
+					isCtrl = e.which === modifier ? false : isCtrl;
+				};
+
+				customizePostShortcuts.keysDown = function( e ) {
+					isShift = e.which === 16 ? true : isCtrl;
+					isCtrl = e.which === modifier ? true : isCtrl;
+					if ( e.which === 69 && isCtrl && isShift ) {
+						$( document ).trigger('customizePostCtrlShiftE');
+					}
+				};
+
+				/**
+				 * Add keyboard handlers to Customizer.
+				 */
+				$( '#customize-controls, #customize-preview' ).on( 'keyup', customizePostShortcuts.keysUp );
+				$( '#customize-controls, #customize-preview' ).on( 'keydown', customizePostShortcuts.keysDown );
+
+				/**
+				 * Add keyboard handlers to Editor.
+				 */
+				$(document.getElementById('customize-posts-content_ifr').contentWindow.document).on( 'keyup', customizePostShortcuts.keysUp );
+				$(document.getElementById('customize-posts-content_ifr').contentWindow.document).on( 'keydown', customizePostShortcuts.keysDown );
+
+			})();
+
 
 			/**
 			 * Expand the editor and focus on it when the post content control is focused.
@@ -273,6 +330,7 @@
 				control.editorToggleExpandButton.attr( 'id', textarea.attr( 'id' ) );
 				textarea.attr( 'id', '' );
 				control.container.append( control.editorToggleExpandButton );
+				control.container.append( control.editorToggleExpandButtonShortcut );
 			} );
 
 			// Remove the setting from the settingValidationMessages since it is not specific to this field.

--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -143,7 +143,7 @@
 			var section = this, control, setting = api( section.id ), editor;
 
 			// Get shortcut label for Mac or PC
-			var shortcutLabel = navigator.appVersion.indexOf( 'Mac' ) !== - 1 ? api.Posts.data.l10n.keyboardToggle.mac : api.Posts.data.l10n.keyboardToggle.pc;
+			var shortcutLabel = navigator.appVersion.indexOf( 'Mac' ) !== -1 ? api.Posts.data.l10n.keyboardToggle.mac : api.Posts.data.l10n.keyboardToggle.pc;
 
 			control = new api.controlConstructor.dynamic( section.id + '[post_content]', {
 				params: {
@@ -234,7 +234,7 @@
 					api.Posts.postIdInput.val( section.params.post_id );
 
 					/** Respond to Crtl/Cmnd+Shift+E */
-					$( document ).on('customizePostCtrlShiftE', function() {
+					$( document ).on( 'customizePostCtrlShiftE', function() {
 						control.editorExpanded.set( ! control.editorExpanded() );
 						if ( control.editorExpanded() ) {
 							editor.focus();
@@ -246,7 +246,7 @@
 					control.editorExpanded.set( false );
 
 					/** Remove Ctrl/Cmd+Shift+E trigger handler. */
-					$( document ).off('customizePostCtrlShiftE');
+					$( document ).off( 'customizePostCtrlShiftE' );
 				}
 			} );
 
@@ -265,23 +265,23 @@
 			 * Create Ctrl/Cmnd+Shift+E shortcut trigger.
 			 * This adds the `customizePostCtrlShiftE` trigger to the document.
 			 */
-			(function(){
+			( function() {
 
-				var isCtrl = false, // status of control/command key
-					isShift = false, // status of shift key
-					modifier = navigator.appVersion.indexOf( 'Mac' ) !== - 1 ? 91 : 17, // use command (91) for Mac
+				var isCtrl = false, // Status of control/command key
+					isShift = false, // Status of shift key
+					modifier = navigator.appVersion.indexOf( 'Mac' ) !== -1 ? 91 : 17, // use command (91) for Mac
 					customizePostShortcuts = customizePostShortcuts || {};
 
 				customizePostShortcuts.keysUp = function( e ) {
-					isShift = e.which === 16 ? false : isCtrl;
+					isShift = 16 === e.which ? false : isCtrl;
 					isCtrl = e.which === modifier ? false : isCtrl;
 				};
 
 				customizePostShortcuts.keysDown = function( e ) {
-					isShift = e.which === 16 ? true : isCtrl;
+					isShift = 16 === e.which ? true : isCtrl;
 					isCtrl = e.which === modifier ? true : isCtrl;
-					if ( e.which === 69 && isCtrl && isShift ) {
-						$( document ).trigger('customizePostCtrlShiftE');
+					if ( 69 === e.which && isCtrl && isShift ) {
+						$( document ).trigger( 'customizePostCtrlShiftE' );
 					}
 				};
 
@@ -294,11 +294,10 @@
 				/**
 				 * Add keyboard handlers to Editor.
 				 */
-				$(document.getElementById('customize-posts-content_ifr').contentWindow.document).on( 'keyup', customizePostShortcuts.keysUp );
-				$(document.getElementById('customize-posts-content_ifr').contentWindow.document).on( 'keydown', customizePostShortcuts.keysDown );
+				$( document.getElementById( 'customize-posts-content_ifr' ).contentWindow.document ).on( 'keyup', customizePostShortcuts.keysUp );
+				$( document.getElementById( 'customize-posts-content_ifr' ).contentWindow.document ).on( 'keydown', customizePostShortcuts.keysDown );
 
-			})();
-
+			} )();
 
 			/**
 			 * Expand the editor and focus on it when the post content control is focused.

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -357,6 +357,10 @@ final class WP_Customize_Posts {
 				'overrideButtonText' => __( 'Override', 'customize-posts' ),
 				'openEditor' => __( 'Open Editor', 'customize-posts' ),
 				'closeEditor' => __( 'Close Editor', 'customize-posts' ),
+				'keyboardToggle' => array(
+					'mac' => '&#x2318;&#x21E7;E',
+					'pc' => 'Ctrl+Shift+E',
+				),
 			),
 		);
 


### PR DESCRIPTION
- Creates a new customizePostCtrlShiftE trigger for Customizer and for the
  editor.

- Binds the new trigger to open and close the editor when Ctrl+Shift+E (PC) or
  Cmd+Shift+E (Mac) is pressed.