### PR TITLE
Harden editor

### DIFF
--- a/css/customize-posts.css
+++ b/css/customize-posts.css
@@ -67,3 +67,20 @@ body:not( .customize-posts-content-editor-pane-open ) div.mce-fullscreen {
 }
 
 /* @todo Mobile support for rich text editor */
+
+.wp-customizer #wp-link-backdrop {
+	z-index: 500100; /* originally 100100, but z-index of .wp-full-overlay is 500000 */
+}
+.wp-customizer .ui-autocomplete.wplink-autocomplete {
+	z-index: 500110; /* originally 100110, but z-index of .wp-full-overlay is 500000 */
+}
+.wp-customizer div.mce-inline-toolbar-grp {
+	z-index: 500100; /* originally 100100, but z-index of .wp-full-overlay is 500000 */
+}
+.wp-customizer #wp-link-wrap {
+	z-index: 500105; /* originally 100105, but z-index of .wp-full-overlay is 500000 */
+}
+.wp-customizer #wp_editbtns,
+.wp-customizer #wp_gallerybtns {
+	z-index: 500020; /* originally 100020, but z-index of .wp-full-overlay is 500000 */
+}

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -287,6 +287,9 @@ final class WP_Customize_Posts {
 	public function enqueue_editor() {
 		add_action( 'customize_controls_print_footer_scripts', array( $this, 'render_editor' ), 0 );
 
+		// Note that WP_Customize_Widgets::print_footer_scripts() happens at priority 10.
+		add_action( 'customize_controls_print_footer_scripts', array( $this, 'maybe_do_admin_print_footer_scripts' ), 20 );
+
 		// @todo These should be included in \_WP_Editors::editor_settings()
 		if ( false === has_action( 'customize_controls_print_footer_scripts', array( '_WP_Editors', 'enqueue_scripts' ) ) ) {
 			add_action( 'customize_controls_print_footer_scripts', array( '_WP_Editors', 'enqueue_scripts' ) );
@@ -314,5 +317,29 @@ final class WP_Customize_Posts {
 		) );
 
 		echo '</div>';
+	}
+
+	/**
+	 * Do the admin_print_footer_scripts actions if not done already.
+	 *
+	 * Another possibility here is to opt-in selectively to the desired widgets
+	 * via:
+	 * Shortcode_UI::get_instance()->action_admin_enqueue_scripts();
+	 * Shortcake_Bakery::get_instance()->action_admin_enqueue_scripts();
+	 *
+	 * Note that this action is also done in WP_Customize_Widgets::print_footer_scripts()
+	 * at priority 10, so this method runs at a later priority to ensure the action is
+	 * not done twice.
+	 */
+	public function maybe_do_admin_print_footer_scripts() {
+		if ( ! did_action( 'admin_print_footer_scripts' ) ) {
+			/** This action is documented in wp-admin/admin-footer.php */
+			do_action( 'admin_print_footer_scripts' );
+		}
+
+		if ( ! did_action( 'admin_footer-post.php' ) ) {
+			/** This action is documented in wp-admin/admin-footer.php */
+			do_action( 'admin_footer-post.php' );
+		}
 	}
 }


### PR DESCRIPTION
Ensures that the link modal, autocomplete, inline toolbar, and other elements in the editor can appear.

Makes sure that the editor integration works when `widgets` component is filtered to be disabled in the Customizer (not that anyone should ever do this :wink:)