### PR TITLE
Fix compatibility with Customize Snapshots

### DIFF
--- a/php/class-wp-customize-post-setting.php
+++ b/php/class-wp-customize-post-setting.php
@@ -479,7 +479,11 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 	 * @return bool
 	 */
 	public function preview() {
+		if ( $this->is_previewed ) {
+			return true;
+		}
 		$this->posts_component->preview->previewed_post_settings[ $this->post_id ] = $this;
+		$this->posts_component->preview->add_preview_filters();
 		$this->is_previewed = true;
 		return true;
 	}

--- a/php/class-wp-customize-post-setting.php
+++ b/php/class-wp-customize-post-setting.php
@@ -134,9 +134,6 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 	 * @return bool False if the post data did not apply.
 	 */
 	public function override_post_data( WP_Post &$post ) {
-		if ( ! $this->posts_component->current_user_can_edit_post( $post ) ) {
-			return false;
-		}
 		if ( $post->ID !== $this->post_id ) {
 			return false;
 		}
@@ -265,13 +262,6 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 
 		$update = ( $this->post_id > 0 );
 		$post_type_obj = get_post_type_object( $this->post_type );
-		if ( ! $this->check_capabilities() ) {
-			if ( $strict ) {
-				return new WP_Error( 'not_allowed' );
-			} else {
-				return null;
-			}
-		}
 
 		if ( $strict && ! empty( $post_data['post_type'] ) && $post_data['post_type'] !== $this->post_type ) {
 			return new WP_Error( 'bad_post_type' );
@@ -490,6 +480,10 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 
 	/**
 	 * Update the post.
+	 *
+	 * Please note that the capability check will have already been done.
+	 *
+	 * @see WP_Customize_Setting::save()
 	 *
 	 * @param string $data The value to update.
 	 * @return bool The result of saving the value.

--- a/php/class-wp-customize-postmeta-setting.php
+++ b/php/class-wp-customize-postmeta-setting.php
@@ -205,7 +205,9 @@ class WP_Customize_Postmeta_Setting extends WP_Customize_Setting {
 	/**
 	 * Update the post.
 	 *
-	 * @access public
+	 * Please note that the capability check will have already been done.
+	 *
+	 * @see WP_Customize_Setting::save()
 	 *
 	 * @param string $meta_value The value to update.
 	 * @return bool The result of saving the value.

--- a/php/class-wp-customize-postmeta-setting.php
+++ b/php/class-wp-customize-postmeta-setting.php
@@ -197,6 +197,7 @@ class WP_Customize_Postmeta_Setting extends WP_Customize_Setting {
 			$this->posts_component->preview->previewed_postmeta_settings[ $this->post_id ] = array();
 		}
 		$this->posts_component->preview->previewed_postmeta_settings[ $this->post_id ][ $this->meta_key ] = $this;
+		$this->posts_component->preview->add_preview_filters();
 		$this->is_previewed = true;
 		return true;
 	}

--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -81,6 +81,7 @@ final class WP_Customize_Posts_Preview {
 		add_filter( 'the_posts', array( $this, 'filter_the_posts_to_preview_settings' ), 1000 );
 		add_action( 'the_post', array( $this, 'preview_setup_postdata' ) );
 		add_filter( 'get_post_metadata', array( $this, 'filter_get_post_meta_to_preview' ), 1000, 4 );
+		$this->has_preview_filters = true;
 		return true;
 	}
 
@@ -111,7 +112,7 @@ final class WP_Customize_Posts_Preview {
 
 		$setting_id = WP_Customize_Post_Setting::get_post_setting_id( $post );
 		$setting = $this->component->manager->get_setting( $setting_id );
-		if ( $setting instanceof WP_Customize_Post_Setting && $setting->check_capabilities() ) {
+		if ( $setting instanceof WP_Customize_Post_Setting ) {
 			$prevent_setup_postdata_recursion = true;
 			$setting->override_post_data( $post );
 			setup_postdata( $post );
@@ -127,11 +128,6 @@ final class WP_Customize_Posts_Preview {
 	 */
 	public function filter_the_posts_to_add_dynamic_post_settings_and_sections( array $posts ) {
 		foreach ( $posts as &$post ) {
-
-			if ( ! $this->component->current_user_can_edit_post( $post ) ) {
-				continue;
-			}
-
 			$post_setting_id = WP_Customize_Post_Setting::get_post_setting_id( $post );
 			$this->component->manager->add_dynamic_settings( array( $post_setting_id ) );
 			$setting = $this->component->manager->get_setting( $post_setting_id );
@@ -239,8 +235,6 @@ final class WP_Customize_Posts_Preview {
 			$can_preview = (
 				$postmeta_setting
 				&&
-				$postmeta_setting->check_capabilities()
-				&&
 				array_key_exists( $postmeta_setting->id, $post_values )
 			);
 			if ( $can_preview ) {
@@ -255,7 +249,7 @@ final class WP_Customize_Posts_Preview {
 			$is_recursing = false;
 
 			foreach ( $this->previewed_postmeta_settings[ $object_id ] as $postmeta_setting ) {
-				if ( ! array_key_exists( $postmeta_setting->id, $post_values ) || ! $postmeta_setting->check_capabilities() ) {
+				if ( ! array_key_exists( $postmeta_setting->id, $post_values ) ) {
 					continue;
 				}
 				$meta_value = $postmeta_setting->post_value();

--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -36,6 +36,14 @@ final class WP_Customize_Posts_Preview {
 	public $previewed_postmeta_settings = array();
 
 	/**
+	 * Whether the preview filters have been added.
+	 *
+	 * @see WP_Customize_Posts_Preview::add_preview_filters()
+	 * @var bool
+	 */
+	protected $has_preview_filters = false;
+
+	/**
 	 * Initial loader.
 	 *
 	 * @access public
@@ -55,14 +63,25 @@ final class WP_Customize_Posts_Preview {
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 		add_filter( 'customize_dynamic_partial_args', array( $this, 'filter_customize_dynamic_partial_args' ), 10, 2 );
 		add_filter( 'customize_dynamic_partial_class', array( $this, 'filter_customize_dynamic_partial_class' ), 10, 3 );
-		add_action( 'the_post', array( $this, 'preview_setup_postdata' ) );
-		add_filter( 'the_posts', array( $this, 'filter_the_posts_to_add_dynamic_post_settings_and_preview' ), 1000 );
-		add_filter( 'get_post_metadata', array( $this, 'filter_get_post_meta_to_preview' ), 1000, 4 );
+		add_filter( 'the_posts', array( $this, 'filter_the_posts_to_add_dynamic_post_settings_and_sections' ), 1000 );
 		add_filter( 'get_post_metadata', array( $this, 'filter_get_post_meta_to_add_dynamic_postmeta_settings' ), 1000, 4 );
 		add_action( 'wp_footer', array( $this, 'export_preview_data' ), 10 );
 		add_filter( 'edit_post_link', array( $this, 'filter_edit_post_link' ), 10, 2 );
 		add_filter( 'get_edit_post_link', array( $this, 'filter_get_edit_post_link' ), 10, 2 );
 		add_filter( 'infinite_scroll_results', array( $this, 'filter_infinite_scroll_results' ), 10, 3 );
+	}
+
+	/**
+	 * Add preview filters for post and postmeta settings.
+	 */
+	public function add_preview_filters() {
+		if ( $this->has_preview_filters ) {
+			return false;
+		}
+		add_filter( 'the_posts', array( $this, 'filter_the_posts_to_preview_settings' ), 1000 );
+		add_action( 'the_post', array( $this, 'preview_setup_postdata' ) );
+		add_filter( 'get_post_metadata', array( $this, 'filter_get_post_meta_to_preview' ), 1000, 4 );
+		return true;
 	}
 
 	/**
@@ -101,12 +120,12 @@ final class WP_Customize_Posts_Preview {
 	}
 
 	/**
-	 * Create dynamic post setting for posts queried in the page, and apply changes to any dirty settings.
+	 * Create dynamic post settings and sections for posts queried in the page.
 	 *
 	 * @param array $posts Posts.
 	 * @return array
 	 */
-	public function filter_the_posts_to_add_dynamic_post_settings_and_preview( array $posts ) {
+	public function filter_the_posts_to_add_dynamic_post_settings_and_sections( array $posts ) {
 		foreach ( $posts as &$post ) {
 
 			if ( ! $this->component->current_user_can_edit_post( $post ) ) {
@@ -123,9 +142,21 @@ final class WP_Customize_Posts_Preview {
 				) );
 				$this->component->manager->add_section( $section );
 			}
+		}
+		return $posts;
+	}
 
+	/**
+	 * Override post data for previewed settings.
+	 *
+	 * @param array $posts Posts.
+	 * @return array
+	 */
+	public function filter_the_posts_to_preview_settings( array $posts ) {
+		foreach ( $posts as &$post ) {
+			$post_setting_id = WP_Customize_Post_Setting::get_post_setting_id( $post );
 			$setting = $this->component->manager->get_setting( $post_setting_id );
-			if ( $setting instanceof WP_Customize_Post_Setting ) {
+			if ( $setting instanceof WP_Customize_Post_Setting && isset( $this->previewed_post_settings[ $post->ID ] ) ) {
 				$setting->override_post_data( $post );
 			}
 		}

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -52,10 +52,6 @@ final class WP_Customize_Posts {
 	public function __construct( WP_Customize_Manager $manager ) {
 		$this->manager = $manager;
 
-		if ( ! current_user_can( 'edit_posts' ) ) {
-			return;
-		}
-
 		require_once dirname( __FILE__ ) . '/class-wp-customize-posts-preview.php';
 		require_once dirname( __FILE__ ) . '/class-wp-customize-posts-panel.php';
 		require_once dirname( __FILE__ ) . '/class-wp-customize-post-section.php';
@@ -90,10 +86,6 @@ final class WP_Customize_Posts {
 		$post_types = array();
 		$post_type_objects = get_post_types( array(), 'objects' );
 		foreach ( $post_type_objects as $post_type_object ) {
-			if ( ! current_user_can( $post_type_object->cap->edit_posts ) ) {
-				continue;
-			}
-
 			$is_included = $post_type_object->show_ui;
 			if ( isset( $post_type_object->show_in_customizer ) ) {
 				$is_included = $post_type_object->show_in_customizer;
@@ -433,6 +425,10 @@ final class WP_Customize_Posts {
 
 		$post_types = array();
 		foreach ( $this->get_post_types() as $post_type => $post_type_obj ) {
+			if ( ! current_user_can( $post_type_obj->cap->edit_posts ) ) {
+				continue;
+			}
+
 			$post_types[ $post_type ] = wp_array_slice_assoc( (array) $post_type_obj, array(
 				'name',
 				'supports',

--- a/tests/php/test-class-wp-customize-post-setting.php
+++ b/tests/php/test-class-wp-customize-post-setting.php
@@ -302,18 +302,6 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 	 *
 	 * @see WP_Customize_Post_Setting::sanitize()
 	 */
-	public function test_sanitize_unauthorized() {
-		$setting = $this->create_post_setting();
-		wp_set_current_user( 0 );
-		$this->assertNull( $setting->sanitize( array( 'post_title' => '' ), false ) );
-		$this->assertInstanceOf( 'WP_Error', $setting->sanitize( array( 'post_title' => '' ), true ) );
-	}
-
-	/**
-	 * Test sanitize().
-	 *
-	 * @see WP_Customize_Post_Setting::sanitize()
-	 */
 	public function test_sanitize_empty_content() {
 		$setting = $this->create_post_setting();
 		$error = $setting->sanitize( array( 'post_title' => '', 'post_content' => '' ), true );

--- a/tests/php/test-class-wp-customize-post-setting.php
+++ b/tests/php/test-class-wp-customize-post-setting.php
@@ -286,10 +286,6 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 			'post_author' => $this->user_id,
 		);
 		$setting = $this->create_post_setting( $post_arr );
-//		$post = get_post( $this->factory()->post->create( $post_arr ) );
-//		$setting_id = WP_Customize_Post_Setting::get_post_setting_id( $post );
-//		$setting = new WP_Customize_Post_Setting( $this->wp_customize, $setting_id );
-
 		$post_data = $setting->get_post_data( get_post( $setting->post_id ) );
 		$this->assertEqualSets( array_keys( $post_data ), array_keys( $setting->default ) );
 		$this->assertEquals( $post_arr['post_author'], $post_data['post_author'] );

--- a/tests/php/test-class-wp-customize-posts-preview.php
+++ b/tests/php/test-class-wp-customize-posts-preview.php
@@ -124,14 +124,27 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 		$this->assertEquals( 10, has_action( 'wp_enqueue_scripts', array( $preview, 'enqueue_scripts' ) ) );
 		$this->assertEquals( 10, has_filter( 'customize_dynamic_partial_args', array( $preview, 'filter_customize_dynamic_partial_args' ) ) );
 		$this->assertEquals( 10, has_filter( 'customize_dynamic_partial_class', array( $preview, 'filter_customize_dynamic_partial_class' ) ) );
-		$this->assertEquals( 10, has_action( 'the_post', array( $preview, 'preview_setup_postdata' ) ) );
-		$this->assertEquals( 1000, has_filter( 'the_posts', array( $preview, 'filter_the_posts_to_add_dynamic_post_settings_and_preview' ) ) );
-		$this->assertEquals( 1000, has_filter( 'get_post_metadata', array( $preview, 'filter_get_post_meta_to_preview' ) ) );
+
+		$this->assertEquals( 1000, has_filter( 'the_posts', array( $preview, 'filter_the_posts_to_add_dynamic_post_settings_and_sections' ) ) );
 		$this->assertEquals( 1000, has_filter( 'get_post_metadata', array( $preview, 'filter_get_post_meta_to_add_dynamic_postmeta_settings' ) ) );
 		$this->assertEquals( 10, has_action( 'wp_footer', array( $preview, 'export_preview_data' ) ) );
 		$this->assertEquals( 10, has_filter( 'edit_post_link', array( $preview, 'filter_edit_post_link' ) ) );
 		$this->assertEquals( 10, has_filter( 'get_edit_post_link', array( $preview, 'filter_get_edit_post_link' ) ) );
 		$this->assertEquals( 10, has_filter( 'infinite_scroll_results', array( $preview, 'filter_infinite_scroll_results' ) ) );
+	}
+
+	/**
+	 * Test add_preview_filters().
+	 *
+	 * @see WP_Customize_Posts_Preview::add_preview_filters()
+	 */
+	public function test_add_preview_filters() {
+		$preview = new WP_Customize_Posts_Preview( $this->posts_component );
+		$this->assertTrue( $preview->add_preview_filters() );
+		$this->assertEquals( 10, has_action( 'the_post', array( $preview, 'preview_setup_postdata' ) ) );
+		$this->assertEquals( 1000, has_filter( 'the_posts', array( $preview, 'filter_the_posts_to_preview_settings' ) ) );
+		$this->assertEquals( 1000, has_filter( 'get_post_metadata', array( $preview, 'filter_get_post_meta_to_preview' ) ) );
+		$this->assertFalse( $preview->add_preview_filters() );
 	}
 
 	/**
@@ -174,11 +187,11 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test filter_the_posts_to_add_dynamic_post_settings_and_preview().
+	 * Test filter_the_posts_to_add_dynamic_post_settings_and_sections().
 	 *
-	 * @see WP_Customize_Posts_Preview::filter_the_posts_to_add_dynamic_post_settings_and_preview()
+	 * @see WP_Customize_Posts_Preview::filter_the_posts_to_add_dynamic_post_settings_and_sections()
 	 */
-	public function test_filter_the_posts_to_add_dynamic_post_settings_and_preview() {
+	public function filter_the_posts_to_add_dynamic_post_settings_and_sections() {
 		$post = get_post( $this->post_id );
 		$original_post_content = $post->post_content;
 		$input_posts = array( $post );
@@ -196,13 +209,13 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 		$section_id = sprintf( 'post[%s][%d]', $post->post_type, $post->ID );
 
 		wp_set_current_user( 0 );
-		$filtered_posts = $preview->filter_the_posts_to_add_dynamic_post_settings_and_preview( $input_posts );
+		$filtered_posts = $preview->filter_the_posts_to_add_dynamic_post_settings_and_sections( $input_posts );
 		$section = $this->posts_component->manager->get_section( $section_id );
 		$this->assertEmpty( $section );
 		$this->assertEquals( $original_post_content, $filtered_posts[0]->post_content );
 
 		wp_set_current_user( $this->user_id );
-		$filtered_posts = $preview->filter_the_posts_to_add_dynamic_post_settings_and_preview( $input_posts );
+		$filtered_posts = $preview->filter_the_posts_to_add_dynamic_post_settings_and_sections( $input_posts );
 		$section = $this->posts_component->manager->get_section( $section_id );
 		$this->assertNotEmpty( $section );
 		$this->assertNotEquals( $original_post_content, $filtered_posts[0]->post_content );
@@ -285,12 +298,6 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 
 		// Test with post value.
 		$this->posts_component->manager->set_post_value( $setting_id, $preview_meta_value );
-		wp_set_current_user( 0 );
-		$this->assertNull( $preview->filter_get_post_meta_to_preview( null, $this->post_id, $meta_key, true ) );
-		$meta_values = $preview->filter_get_post_meta_to_preview( null, $this->post_id, '', true );
-		$this->assertArrayHasKey( $meta_key, $meta_values );
-		$this->assertEquals( array( maybe_serialize( $original_meta_value ) ), $meta_values[ $meta_key ] );
-
 		wp_set_current_user( $this->user_id );
 		$this->assertEquals( $preview_meta_value, $preview->filter_get_post_meta_to_preview( null, $this->post_id, $meta_key, true ) );
 		$meta_values = $preview->filter_get_post_meta_to_preview( null, $this->post_id, '', true );

--- a/tests/php/test-class-wp-customize-posts.php
+++ b/tests/php/test-class-wp-customize-posts.php
@@ -120,18 +120,6 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that show_in_customizer being set with missing perms excludes the post type.
-	 *
-	 * @see WP_Customize_Posts::get_post_types()
-	 */
-	public function test_get_post_types_fails() {
-		wp_set_current_user( self::factory()->user->create( array( 'role' => 'subscriber' ) ) );
-		register_post_type( 'customize_test', array( 'show_in_customizer' => true ) );
-		$this->assertArrayNotHasKey( 'customize_test', $this->posts->get_post_types() );
-		_unregister_post_type( 'customize_test' );
-	}
-
-	/**
 	 * Test that show_in_customizer being set includes the post type.
 	 *
 	 * @see WP_Customize_Posts::get_post_types()


### PR DESCRIPTION
Customize Posts is not working with Customize Snapshots.

I found that post and postmeta changes were not applied on the frontend when the UUID was supplied. This was due to the preview filters being added in the `customize_preview_init` action as opposed to being added whenever a setting's `preview()` method was called.

I also found that even with this fixed, the settings would not apply on the frontend for users who were not authenticated. There were a lot of capability checks added for _previewing_ settings which I now believe to be an error. 