### PR TITLE
Fix handling the discovery of postmeta settings for posts that lack any postmeta

### DIFF
--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -147,9 +147,9 @@ final class WP_Customize_Posts_Preview {
 		}
 
 		if ( '' === $meta_key ) {
-			if ( NULL !== $value ) {
+			if ( null !== $value ) {
 				$meta_keys = array_keys( $value );
-			} else  {
+			} else {
 				$meta_keys = array();
 			}
 		} else {

--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -157,9 +157,11 @@ final class WP_Customize_Posts_Preview {
 		}
 
 		$setting_ids = array();
-		foreach ( $meta_keys as $key ) {
-			if ( isset( $this->component->registered_post_meta[ $post->post_type ][ $key ] ) ) {
-				$setting_ids[] = WP_Customize_Postmeta_Setting::get_post_meta_setting_id( $post, $key );
+		if ( ! empty( $meta_keys ) ) {
+			foreach ( $meta_keys as $key ) {
+				if ( isset( $this->component->registered_post_meta[ $post->post_type ][ $key ] ) ) {
+					$setting_ids[] = WP_Customize_Postmeta_Setting::get_post_meta_setting_id( $post, $key );
+				}
 			}
 		}
 		$this->component->manager->add_dynamic_settings( $setting_ids );

--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -147,7 +147,11 @@ final class WP_Customize_Posts_Preview {
 		}
 
 		if ( '' === $meta_key ) {
-			$meta_keys = array_keys( $value );
+			if ( NULL !== $value ) {
+				$meta_keys = array_keys( $value );
+			} else  {
+				$meta_keys = array();
+			}
 		} else {
 			$meta_keys = array( $meta_key );
 		}


### PR DESCRIPTION
I encountered two warnings on a basic environment, which I fixed with some extra conditionals.

Warning: array_keys() expects parameter 1 to be array, null given in
/wp-content/plugins/customize-posts/php/class-w
p-customize-posts-preview.php on line 150

Warning: Invalid argument supplied for foreach() in
/wp-content/plugins/customize-posts/php/class-w
p-customize-posts-preview.php on line 156

