### PR TITLE
Fix media buttons

### DIFF
--- a/css/customize-posts.css
+++ b/css/customize-posts.css
@@ -23,8 +23,8 @@ div.customize-setting-validation-message.error {
 #customize-posts-content-editor-pane {
 	border-top: solid 1px #ddd;
 	position: absolute;
-	height: 329px;
-	bottom: -330px;
+	height: 300px;
+	bottom: -301px;
 	right: 0;
 	left: 0;
 	z-index: 20;
@@ -35,10 +35,20 @@ div.customize-setting-validation-message.error {
 
 	/* @todo This should have visibility:hidden to ensure accessible when closed. */
 }
+
+body.mce-fullscreen.customize-posts-content-editor-pane-open #customize-posts-content-editor-pane {
+	top: 0;
+}
+
+body.customize-posts-content-editor-pane-open #customize-posts-content-editor-pane {
+	bottom: 0;
+}
+
 #customize-posts-content-editor-pane .wp-editor-tools {
 	padding-top: 5px;
 	padding-right: 10px;
 }
+
 #customize-posts-content-editor-pane .wp-media-buttons {
 	padding-left: 5px;
 }
@@ -48,22 +58,20 @@ div.customize-setting-validation-message.error {
 }
 
 body.customize-posts-content-editor-pane-open #customize-preview {
-	bottom: 329px;
-}
-body.customize-posts-content-editor-pane-open:not( .mce-fullscreen ) #customize-posts-content-editor-pane {
-	bottom: 0;
+	bottom: 300px;
 }
 
 body.mce-fullscreen #customize-preview {
 	bottom: 0;
 }
 
-/* @todo Ideally this would include the media buttons in view */
-#wp-customize-posts-content-editor-container div.mce-fullscreen {
-	left: 300px;
+body.mce-fullscreen.customize-posts-content-editor-pane-open div.mce-fullscreen {
+	position: relative;
+	left: 0;
 }
-body:not( .customize-posts-content-editor-pane-open ) div.mce-fullscreen {
-	display: none;
+
+#wp-customize-posts-content-editor-container {
+	border-left: 0;
 }
 
 /* @todo Mobile support for rich text editor */

--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -237,6 +237,7 @@
 				} else {
 					editor.off( 'input change keyup', control.onVisualEditorChange );
 					textarea.off( 'input', control.onTextEditorChange );
+					$( '.mce-active' ).click();
 				}
 			} );
 

--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -237,6 +237,9 @@
 				} else {
 					editor.off( 'input change keyup', control.onVisualEditorChange );
 					textarea.off( 'input', control.onTextEditorChange );
+
+					// Cancel link and force a click event to exit fullscreen & kitchen sink mode.
+					editor.execCommand( 'wp_link_cancel' );
 					$( '.mce-active' ).click();
 				}
 			} );


### PR DESCRIPTION
I also added a little JS to click the active mce button and close the link popup if it's open when you click the "Close Editor" button. That way it reverts to the original state when you close the editor.

![screen shot 2016-04-23 at 2 51 23 pm](https://cloud.githubusercontent.com/assets/62798/14764167/0204ab72-0963-11e6-802f-746951e44b50.png)

![screen shot 2016-04-23 at 2 51 35 pm](https://cloud.githubusercontent.com/assets/62798/14764168/0631b64a-0963-11e6-94b3-510b46d1ceb5.png)

Fixes #80 