### PR TITLE
Add support for featured image

### DIFF
--- a/js/customize-controls-patched-36521.js
+++ b/js/customize-controls-patched-36521.js
@@ -1,0 +1,87 @@
+/* eslint consistent-this: [ "error", "control" ] */
+
+(function( api, $ ) {
+	'use strict';
+
+	/**
+	 * Patched ready method for MediaControl. Remove once fix in #36521 is available.
+	 *
+	 * @link https://core.trac.wordpress.org/ticket/36521
+	 */
+	api.MediaControl.prototype.ready = function() {
+		var control = this;
+
+		// Shortcut so that we don't have to use _.bind every time we add a callback.
+		_.bindAll( control, 'restoreDefault', 'removeFile', 'openFrame', 'select', 'pausePlayer' );
+
+		// Bind events, with delegation to facilitate re-rendering.
+		control.container.on( 'click keydown', '.upload-button', control.openFrame );
+		control.container.on( 'click keydown', '.upload-button', control.pausePlayer );
+		control.container.on( 'click keydown', '.thumbnail-image img', control.openFrame );
+		control.container.on( 'click keydown', '.default-button', control.restoreDefault );
+		control.container.on( 'click keydown', '.remove-button', control.pausePlayer );
+		control.container.on( 'click keydown', '.remove-button', control.removeFile );
+		control.container.on( 'click keydown', '.remove-button', control.cleanupPlayer );
+
+		// Resize the player controls when it becomes visible (ie when section is expanded)
+		api.section( control.section() ).container
+			.on( 'expanded', function() {
+				if ( control.player ) {
+					control.player.setControlsSize();
+				}
+			})
+			.on( 'collapsed', function() {
+				control.pausePlayer();
+			});
+
+		/**
+		 * Set attachment data and render content.
+		 *
+		 * Note that BackgroundImage.prototype.ready applies this ready method
+		 * to itself. Since BackgroundImage is an UploadControl, the value
+		 * is the attachment URL instead of the attachment ID. In this case
+		 * we skip fetching the attachment data because we have no ID available,
+		 * and it is the responsibility of the UploadControl to set the control's
+		 * attachmentData before calling the renderContent method.
+		 *
+		 * @param {number|string} value Attachment
+		 */
+		function setAttachmentDataAndRenderContent( value ) {
+			var hasAttachmentData = $.Deferred(), attachmentId = value;
+
+			if ( control.extended( api.UploadControl ) ) {
+				hasAttachmentData.resolve();
+			} else {
+				attachmentId = parseInt( attachmentId, 10 );
+				if ( _.isNaN( attachmentId ) || attachmentId <= 0 ) {
+					delete control.params.attachment;
+					hasAttachmentData.resolve();
+				} else if ( control.params.attachment && control.params.attachment.id === attachmentId ) {
+					hasAttachmentData.resolve();
+				}
+			}
+
+			// Fetch the attachment data.
+			if ( 'pending' === hasAttachmentData.state() ) {
+				wp.media.attachment( attachmentId ).fetch().done( function() {
+					control.params.attachment = this.attributes;
+					hasAttachmentData.resolve();
+
+					// Send attachment information to the preview for possible use in `postMessage` transport.
+					wp.customize.previewer.send( control.setting.id + '-attachment-data', this.attributes );
+				} );
+			}
+
+			hasAttachmentData.done( function() {
+				control.renderContent();
+			} );
+		}
+
+		// Ensure attachment data is initially set (for dynamically-instantiated controls).
+		setAttachmentDataAndRenderContent( control.setting() );
+
+		// Update the attachment data and re-render the control when the setting changes.
+		control.setting.bind( setAttachmentDataAndRenderContent );
+	};
+
+})( wp.customize, jQuery );

--- a/js/customize-controls-patched-36521.js
+++ b/js/customize-controls-patched-36521.js
@@ -6,6 +6,8 @@
 	/**
 	 * Patched ready method for MediaControl. Remove once fix in #36521 is available.
 	 *
+	 * @see FeaturedImage.updateSelection()
+	 *
 	 * @link https://core.trac.wordpress.org/ticket/36521
 	 */
 	api.MediaControl.prototype.ready = function() {

--- a/js/customize-featured-image.js
+++ b/js/customize-featured-image.js
@@ -43,7 +43,7 @@ var CustomizeFeaturedImage = (function( api ) {
 	 * @returns {wp.customize.Control|null} The control.
 	 */
 	component.addControl = function( section ) {
-		var control, controlId, settingId, postTypeObj, originalValidate;
+		var control, controlId, settingId, postTypeObj, originalValidate, originalInitFrame;
 		if ( ! section.extended( api.Posts.PostSection ) ) {
 			return null;
 		}
@@ -116,8 +116,29 @@ var CustomizeFeaturedImage = (function( api ) {
 			}
 		} );
 
+		originalInitFrame = control.initFrame;
+
+		/**
+		 * Initialize the media frame and preselect
+		 *
+		 * @todo The wp.customize.MediaControl should do this in core.
+		 */
+		control.initFrame = function initFrameAndSetInitialSelection() {
+			originalInitFrame.call( this );
+			control.frame.on( 'open', function() {
+				var selection = control.frame.state().get( 'selection' );
+				if ( control.params.attachment && control.params.attachment.id ) {
+
+					// @todo This should also pre-check the images in the media library grid.
+					selection.reset( [ control.params.attachment ] );
+				} else {
+					selection.reset( [] );
+				}
+			} );
+		};
+
 		control.active.set( true );
-		control.active.validate = function() {
+		control.active.validate = function validateForcingTrue() {
 			return true;
 		};
 

--- a/js/customize-featured-image.js
+++ b/js/customize-featured-image.js
@@ -70,25 +70,6 @@ var CustomizeFeaturedImage = (function( api ) {
 			} );
 		}
 
-		/*
-		 * When a featured image is removed from a media control, normally its
-		 * value is set to an empty string. There is no way to differentiate
-		 * between an empty string value and an unpopulated postmeta setting,
-		 * since get_post_meta() returns an empty string for postmeta that don't
-		 * exist. So this forces a value to be sanitized as a discrete -1 value.
-		 */
-		api( settingId, function( setting ) {
-			originalValidate = setting.validate;
-			setting.validate = function validateSetting( value ) {
-				var attachmentId = value;
-				if ( '' === attachmentId ) {
-					attachmentId = -1;
-				}
-				originalValidate.call( this, attachmentId );
-				return attachmentId;
-			};
-		} );
-
 		control = new api.MediaControl( controlId, {
 			params: {
 				section: section.id,

--- a/js/customize-featured-image.js
+++ b/js/customize-featured-image.js
@@ -92,7 +92,7 @@ var CustomizeFeaturedImage = (function( api ) {
 		control = new api.MediaControl( controlId, {
 			params: {
 				section: section.id,
-				priority: 1,
+				priority: 50,
 				label: postTypeObj.labels.featured_image,
 				button_labels: {
 					change: component.data.l10n.default_button_labels.change,

--- a/js/customize-featured-image.js
+++ b/js/customize-featured-image.js
@@ -43,7 +43,7 @@ var CustomizeFeaturedImage = (function( api ) {
 	 * @returns {wp.customize.Control|null} The control.
 	 */
 	component.addControl = function( section ) {
-		var control, controlId, settingId, postTypeObj, originalValidate, originalInitFrame;
+		var control, controlId, settingId, postTypeObj, originalInitFrame;
 		if ( ! section.extended( api.Posts.PostSection ) ) {
 			return null;
 		}

--- a/js/customize-page-template.js
+++ b/js/customize-page-template.js
@@ -1,4 +1,4 @@
-/* global module, EditPostPreviewCustomize, wp, _, _wpCustomizePageTemplateExports */
+/* global module, EditPostPreviewCustomize, wp, _ */
 /* exported CustomizePageTemplate */
 
 var CustomizePageTemplate = (function( api ) {
@@ -15,10 +15,12 @@ var CustomizePageTemplate = (function( api ) {
 
 	/**
 	 * Init component.
+	 *
+	 * @param {object} [configData]
 	 */
-	component.init = function() {
-		if ( 'undefined' !== typeof _wpCustomizePageTemplateExports ) {
-			_.extend( component.data, _wpCustomizePageTemplateExports );
+	component.init = function( configData ) {
+		if ( 'undefined' !== typeof configData ) {
+			_.extend( component.data, configData );
 		}
 		component.extendSections();
 	};
@@ -57,9 +59,9 @@ var CustomizePageTemplate = (function( api ) {
 		// If in page preview, send the updated page template to the post edit screen when it is changed.
 		if ( 'undefined' !== typeof EditPostPreviewCustomize ) {
 			api( settingId, function( setting ) {
-				setting.bind( function( pageTemplate ) {
+				setting.bind( function( value ) {
 					var settings = {};
-					settings[ settingId ] = pageTemplate;
+					settings[ settingId ] = value;
 					EditPostPreviewCustomize.sendSettingsToEditPostScreen( settings );
 				} );
 			} );

--- a/js/customize-page-template.js
+++ b/js/customize-page-template.js
@@ -74,7 +74,7 @@ var CustomizePageTemplate = (function( api ) {
 		control = new api.controlConstructor.dynamic( controlId, {
 			params: {
 				section: section.id,
-				priority: 1,
+				priority: 40,
 				label: component.data.l10n.controlLabel,
 				active: true,
 				settings: {

--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -377,7 +377,7 @@
 			control = new api.controlConstructor.post_discussion_fields( section.id + '[discussion_fields]', {
 				params: {
 					section: section.id,
-					priority: 40,
+					priority: 60,
 					label: api.Posts.data.l10n.fieldDiscussionLabel,
 					active: true,
 					settings: {
@@ -414,7 +414,7 @@
 			control = new api.controlConstructor.dynamic( section.id + '[post_author]', {
 				params: {
 					section: section.id,
-					priority: 50,
+					priority: 70,
 					label: api.Posts.data.l10n.fieldAuthorLabel,
 					active: true,
 					settings: {

--- a/js/customize-preview-featured-image.js
+++ b/js/customize-preview-featured-image.js
@@ -1,5 +1,6 @@
 /* global module, wp, _ */
 /* exported CustomizePreviewFeaturedImage */
+/* eslint consistent-this: [ "error", "partial" ] */
 
 var CustomizePreviewFeaturedImage = (function( api, $ ) {
 	'use strict';

--- a/js/customize-preview-featured-image.js
+++ b/js/customize-preview-featured-image.js
@@ -1,0 +1,77 @@
+/* global module, wp, _ */
+/* exported CustomizePreviewFeaturedImage */
+
+var CustomizePreviewFeaturedImage = (function( api, $ ) {
+	'use strict';
+
+	var component = {
+		data: {}
+	};
+
+	/**
+	 * Init component.
+	 *
+	 * @param {object} [configData]
+	 */
+	component.init = function( configData ) {
+		if ( 'undefined' !== typeof configData ) {
+			_.extend( component.data, configData );
+		}
+		component.registerPartial();
+	};
+
+	component.FeaturedImagePartial = api.selectiveRefresh.Partial.extend({
+
+		/**
+		 * Force fallback (full page refresh) behavior when the featured image is removed.
+		 *
+		 * This is intended to preempt the partial-refresh Ajax request. Otherwise
+		 * the renderContent method will be called which would then do the full
+		 * refresh if the rendered partial is empty.
+		 *
+		 * @returns {jQuery.Promise}
+		 */
+		refresh: function() {
+			var partial = this, setting, refreshPromise;
+			setting = api( partial.params.primarySetting );
+			if ( '' === setting() ) {
+				refreshPromise = $.Deferred();
+				partial.fallback();
+				refreshPromise.reject();
+				return refreshPromise;
+			} else {
+				return api.selectiveRefresh.Partial.prototype.refresh.apply( partial, arguments );
+			}
+		},
+
+		/**
+		 * Refresh the full page if no featured image was rendered.
+		 *
+		 * @todo Remove this?
+		 *
+		 * @param {wp.customize.selectiveRefresh.Placement} placement
+		 */
+		renderContent: function( placement ) {
+			var partial = this;
+			if ( '' === placement.addedContent ) {
+				partial.fallback();
+			} else {
+				api.selectiveRefresh.Partial.prototype.renderContent.call( partial, placement );
+			}
+		}
+	});
+
+	/**
+	 * Register the featured-image partial type.
+	 */
+	component.registerPartial = function() {
+		api.selectiveRefresh.partialConstructor.featured_image = component.FeaturedImagePartial;
+	};
+
+	if ( 'undefined' !== typeof module ) {
+		module.exports = component;
+	}
+
+	return component;
+
+})( wp.customize, jQuery );

--- a/js/edit-post-preview-admin-featured-image.js
+++ b/js/edit-post-preview-admin-featured-image.js
@@ -1,0 +1,30 @@
+/* global jQuery, wp, EditPostPreviewAdmin */
+(function( $ ) {
+	'use strict';
+
+	var metaKey = '_thumbnail_id', inputSelector = '#_thumbnail_id';
+
+	// Handle syncing settings from edit post admin page to Customizer.
+	wp.customize.bind( 'settings-from-edit-post-screen', function( settings ) {
+		var settingId = EditPostPreviewAdmin.getPostMetaSettingId( metaKey );
+		settings[ settingId ] = parseInt( $( inputSelector ).val(), 10 );
+	} );
+
+	// Handle syncing settings from Customizer to edit post admin page.
+	wp.customize.bind( 'settings-from-customizer', function( settings ) {
+		var value, nonce, settingId = EditPostPreviewAdmin.getPostMetaSettingId( metaKey );
+		if ( 'undefined' === typeof settings[ settingId ] ) {
+			return;
+		}
+		value = settings[ settingId ];
+		nonce = $( '#set_post_thumbnail_nonce' ).val();
+		$( inputSelector ).val( value ).trigger( 'change' );
+
+		if ( value > 0 ) {
+			wp.media.featuredImage.set( value );
+		} else {
+			window.WPRemoveThumbnail( nonce );
+		}
+	} );
+
+})( jQuery );

--- a/js/edit-post-preview-admin-page-template.js
+++ b/js/edit-post-preview-admin-page-template.js
@@ -2,17 +2,19 @@
 (function( $ ) {
 	'use strict';
 
+	var metaKey = '_wp_page_template', inputSelector = '#page_template';
+
 	// Handle syncing settings from edit post admin page to Customizer.
 	wp.customize.bind( 'settings-from-edit-post-screen', function( settings ) {
-		var pageTemplateSettingId = EditPostPreviewAdmin.getPostMetaSettingId( '_wp_page_template' );
-		settings[ pageTemplateSettingId ] = $( '#page_template' ).val();
+		var settingId = EditPostPreviewAdmin.getPostMetaSettingId( metaKey );
+		settings[ settingId ] = $( inputSelector ).val();
 	} );
 
 	// Handle syncing settings from Customizer to edit post admin page.
 	wp.customize.bind( 'settings-from-customizer', function( settings ) {
-		var pageTemplateSettingId = EditPostPreviewAdmin.getPostMetaSettingId( '_wp_page_template' );
-		if ( 'undefined' !== typeof settings[ pageTemplateSettingId ] ) {
-			$( '#page_template' ).val( settings[ pageTemplateSettingId ] ).trigger( 'change' );
+		var settingId = EditPostPreviewAdmin.getPostMetaSettingId( metaKey );
+		if ( 'undefined' !== typeof settings[ settingId ] ) {
+			$( inputSelector ).val( settings[ settingId ] ).trigger( 'change' );
 		}
 	} );
 

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -224,6 +224,12 @@ class Customize_Posts_Plugin {
 		$deps = array( 'edit-post-preview-admin' );
 		$in_footer = 1;
 		$wp_scripts->add( $handle, $src, $deps, $this->version, $in_footer );
+
+		$handle = 'customize-preview-featured-image';
+		$src = $plugin_dir_url . 'js/customize-preview-featured-image' . $suffix;
+		$deps = array( 'customize-preview' );
+		$in_footer = 1;
+		$wp_scripts->add( $handle, $src, $deps, $this->version, $in_footer );
 	}
 
 	/**

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -125,6 +125,12 @@ class Customize_Posts_Plugin {
 		$suffix = ( SCRIPT_DEBUG ? '' : '.min' ) . '.js';
 		$plugin_dir_url = plugin_dir_url( dirname( __FILE__ ) );
 
+		$handle = 'customize-controls-patched-36521';
+		$src = $plugin_dir_url . 'js/customize-controls-patched-36521' . $suffix;
+		$deps = array( 'customize-controls' );
+		$in_footer = 1;
+		$wp_scripts->add( $handle, $src, $deps, $this->version, $in_footer );
+
 		$handle = 'customize-posts-panel';
 		$src = $plugin_dir_url . 'js/customize-posts-panel' . $suffix;
 		$deps = array( 'customize-controls' );
@@ -154,6 +160,9 @@ class Customize_Posts_Plugin {
 			'customize-dynamic-control',
 			'underscore',
 		);
+		if ( version_compare( str_replace( array( '-src' ), '', $GLOBALS['wp_version'] ), '4.6-beta1', '<' ) ) {
+			$deps[] = 'customize-controls-patched-36521';
+		}
 		$in_footer = 1;
 		$wp_scripts->add( $handle, $src, $deps, $this->version, $in_footer );
 

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -35,6 +35,13 @@ class Customize_Posts_Plugin {
 	public $page_template_controller;
 
 	/**
+	 * Page template controller.
+	 *
+	 * @var WP_Customize_Featured_Image_Controller
+	 */
+	public $featured_image_controller;
+
+	/**
 	 * Plugin constructor.
 	 *
 	 * @access public
@@ -60,7 +67,9 @@ class Customize_Posts_Plugin {
 
 		require_once dirname( __FILE__ ) . '/class-wp-customize-postmeta-controller.php';
 		require_once dirname( __FILE__ ) . '/class-wp-customize-page-template-controller.php';
+		require_once dirname( __FILE__ ) . '/class-wp-customize-featured-image-controller.php';
 		$this->page_template_controller = new WP_Customize_Page_Template_Controller();
+		$this->featured_image_controller = new WP_Customize_Featured_Image_Controller();
 	}
 
 	/**
@@ -190,6 +199,7 @@ class Customize_Posts_Plugin {
 		$in_footer = 1;
 		$wp_scripts->add( $handle, $src, $deps, $this->version, $in_footer );
 
+		// Page templates.
 		$handle = 'customize-page-template';
 		$src = $plugin_dir_url . 'js/customize-page-template' . $suffix;
 		$deps = array( 'customize-controls', 'customize-posts' );
@@ -198,6 +208,19 @@ class Customize_Posts_Plugin {
 
 		$handle = 'edit-post-preview-admin-page-template';
 		$src = $plugin_dir_url . 'js/edit-post-preview-admin-page-template' . $suffix;
+		$deps = array( 'edit-post-preview-admin' );
+		$in_footer = 1;
+		$wp_scripts->add( $handle, $src, $deps, $this->version, $in_footer );
+
+		// Featured images.
+		$handle = 'customize-featured-image';
+		$src = $plugin_dir_url . 'js/customize-featured-image' . $suffix;
+		$deps = array( 'customize-controls', 'customize-posts' );
+		$in_footer = 1;
+		$wp_scripts->add( $handle, $src, $deps, $this->version, $in_footer );
+
+		$handle = 'edit-post-preview-admin-featured-image';
+		$src = $plugin_dir_url . 'js/edit-post-preview-admin-featured-image' . $suffix;
 		$deps = array( 'edit-post-preview-admin' );
 		$in_footer = 1;
 		$wp_scripts->add( $handle, $src, $deps, $this->version, $in_footer );

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -227,7 +227,7 @@ class Customize_Posts_Plugin {
 
 		$handle = 'customize-preview-featured-image';
 		$src = $plugin_dir_url . 'js/customize-preview-featured-image' . $suffix;
-		$deps = array( 'customize-preview' );
+		$deps = array( 'customize-preview', 'customize-selective-refresh' );
 		$in_footer = 1;
 		$wp_scripts->add( $handle, $src, $deps, $this->version, $in_footer );
 	}

--- a/php/class-wp-customize-featured-image-controller.php
+++ b/php/class-wp-customize-featured-image-controller.php
@@ -163,9 +163,9 @@ class WP_Customize_Featured_Image_Controller extends WP_Customize_Postmeta_Contr
 		}
 		$attachment_id = wp_unslash( $_POST[ $this->meta_key ] );
 		$attachment_id = $this->sanitize_value( $attachment_id );
-		if ( -1 === $attachment_id || empty( $attachment_id ) ) {
+		if ( empty( $attachment_id ) ) {
 			return delete_post_thumbnail( $post_id );
-		} elseif ( $attachment_id > 0 ) {
+		} else {
 			return (bool) set_post_thumbnail( $post_id, $attachment_id );
 		}
 	}

--- a/php/class-wp-customize-featured-image-controller.php
+++ b/php/class-wp-customize-featured-image-controller.php
@@ -73,9 +73,9 @@ class WP_Customize_Featured_Image_Controller extends WP_Customize_Postmeta_Contr
 		$exports = array(
 			'l10n' => array(
 				'default_button_labels' => array(
-					'change' => __( 'Change Image', 'customize-post' ),
-					'default' => __( 'Default', 'customize-post' ),
-					'placeholder' => __( 'No image selected', 'customize-post' ),
+					'change' => __( 'Change Image', 'customize-posts' ),
+					'default' => __( 'Default', 'customize-posts' ),
+					'placeholder' => __( 'No image selected', 'customize-posts' ),
 					'remove' => __( 'Remove', 'customize-posts' ),
 					'select' => __( 'Select Image', 'customize-posts' ),
 				),

--- a/php/class-wp-customize-featured-image-controller.php
+++ b/php/class-wp-customize-featured-image-controller.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * Customize Featured Image Controller Class, a.k.a Post Thumbnails.
+ *
+ * @package WordPress
+ * @subpackage Customize
+ */
+
+/**
+ * Class WP_Customize_Featured_Image_Controller
+ */
+class WP_Customize_Featured_Image_Controller extends WP_Customize_Postmeta_Controller {
+
+	const EDIT_POST_SCREEN_UPDATE_NONCE_ARG_NAME = 'set_post_thumbnail_nonce';
+
+	/**
+	 * Meta key.
+	 *
+	 * @var string
+	 */
+	public $meta_key = '_thumbnail_id';
+
+	/**
+	 * Post type support for the postmeta.
+	 *
+	 * @var string
+	 */
+	public $post_type_supports = 'thumbnail';
+
+	/**
+	 * Theme support.
+	 *
+	 * @todo Is this right? If a post type supports featured images, then shouldn't it be allowed?
+	 *
+	 * @var string
+	 */
+	public $theme_supports = 'post-thumbnails';
+
+	/**
+	 * Setting transport.
+	 *
+	 * @var string
+	 */
+	public $setting_transport = 'refresh';
+
+	/**
+	 * Default value.
+	 *
+	 * @var string
+	 */
+	public $default = -1;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array $args Args.
+	 */
+	public function __construct( array $args = array() ) {
+		parent::__construct( $args );
+		$this->override_default_edit_post_screen_functionality();
+	}
+
+	/**
+	 * Enqueue customize scripts.
+	 */
+	public function enqueue_customize_scripts() {
+		$handle = 'customize-featured-image';
+		wp_enqueue_script( $handle );
+		$exports = array(
+			'l10n' => array(
+				'default_button_labels' => array(
+					'change' => __( 'Change Image', 'customize-post' ),
+					'default' => __( 'Default', 'customize-post' ),
+					'placeholder' => __( 'No image selected', 'customize-post' ),
+					'remove' => __( 'Remove', 'customize-posts' ),
+					'select' => __( 'Select Image', 'customize-posts' ),
+				),
+			),
+		);
+		wp_add_inline_script( $handle, sprintf( 'CustomizeFeaturedImage.init( %s );', wp_json_encode( $exports ) ) );
+	}
+
+	/**
+	 * Prevent setting the featured image from the edit post screen from updating the postmeta in place.
+	 *
+	 * @link https://core.trac.wordpress.org/ticket/20299#comment:57
+	 */
+	public function override_default_edit_post_screen_functionality() {
+		add_action( 'wp_ajax_set-post-thumbnail', array( $this, 'handle_ajax_set_post_thumbnail' ), 0 );
+		add_filter( 'admin_post_thumbnail_html', array( $this, 'filter_admin_post_thumbnail_html' ), 10, 3 );
+		add_action( 'save_post', array( $this, 'handle_save_post_thumbnail_id' ) );
+	}
+
+	/**
+	 * Send back the featured image HTML for the selected image.
+	 *
+	 * This Ajax handler is forked from the core wp_ajax_set_post_thumbnail().
+	 * It does the same thing except for actually changing the _thumbnail_id postmeta.
+	 * This handler is added at priority 9 so that it will be called before the
+	 * core handler, and thus short-circuiting it from being called.
+	 *
+	 * @see wp_ajax_set_post_thumbnail()
+	 */
+	public function handle_ajax_set_post_thumbnail() {
+		$json = ! empty( $_REQUEST['json'] ); // New-style request.
+
+		$post_id = intval( $_POST['post_id'] );
+		if ( ! current_user_can( 'edit_post', $post_id ) || ! get_post( $post_id ) ) {
+			wp_die( -1 );
+		}
+		if ( $json ) {
+			check_ajax_referer( "update-post_$post_id" );
+		} else {
+			check_ajax_referer( "set_post_thumbnail-$post_id" );
+		}
+
+		$old_thumbnail_id = get_post_thumbnail_id( $post_id );
+		$new_thumbnail_id = $this->sanitize_value( wp_unslash( $_POST['thumbnail_id'] ) );
+		if ( false === $new_thumbnail_id ) {
+			$return = '<p>' . esc_html__( 'Error: Invalid attachment selected.', 'customize-posts' ) . '</p>';
+			$return .= _wp_post_thumbnail_html( $old_thumbnail_id, $post_id );
+		} elseif ( -1 === $new_thumbnail_id ) {
+			$return = _wp_post_thumbnail_html( null, $post_id );
+		} else {
+			$return = _wp_post_thumbnail_html( $new_thumbnail_id, $post_id );
+		}
+		if ( $json ) {
+			wp_send_json_success( $return );
+		} else {
+			wp_die( $return ); // WPCS: XSS OK.
+		}
+	}
+
+	/**
+	 * Handle saving a featured image from the post edit screen.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function handle_save_post_thumbnail_id( $post_id ) {
+		$nonce_action = 'set_post_thumbnail-' . $post_id;
+		if ( ! check_ajax_referer( $nonce_action, self::EDIT_POST_SCREEN_UPDATE_NONCE_ARG_NAME, false ) ) {
+			return;
+		}
+		if ( ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+		if ( ! isset( $_POST[ $this->meta_key ] ) ) {
+			return;
+		}
+		$attachment_id = wp_unslash( $_POST[ $this->meta_key ] );
+		$attachment_id = $this->sanitize_value( $attachment_id );
+		if ( -1 === $attachment_id ) {
+			delete_post_thumbnail( $post_id );
+		} elseif ( $attachment_id > 0 ) {
+			set_post_thumbnail( $post_id, $attachment_id );
+		}
+	}
+
+	/**
+	 * Inject the featured image attachment ID into the metabox.
+	 *
+	 * Note that this value is also exposed in JS as wp.media.view.settings.post.featuredImageId,
+	 * but there is no input element to pass the selected attachment ID to the server
+	 * when the post is saved. This is because of the unfortunate behavior where changing
+	 * the featured image from the post edit screen will normally update it in-place without
+	 * the ability to preview.
+	 *
+	 * In this controller, the
+	 *
+	 * @param string $content      Admin post thumbnail HTML markup.
+	 * @param int    $post_id      Post ID.
+	 * @param int    $thumbnail_id Thumbnail ID.
+	 * @return string Content.
+	 */
+	public function filter_admin_post_thumbnail_html( $content, $post_id, $thumbnail_id ) {
+		$content .= '<p><strong>' . esc_html__( 'Note: The chosen image will not persist until you save.', 'customize-posts' ) . '</strong></p>';
+		if ( empty( $thumbnail_id ) ) {
+			$thumbnail_id = -1;
+		}
+		$content .= sprintf( '<input type="hidden" id="_thumbnail_id" name="_thumbnail_id" value="%s">', esc_attr( $thumbnail_id ) );
+		$content .= sprintf(
+			'<input type="hidden" name="%1$s" id="%1$s" value="%2$s">',
+			esc_attr( self::EDIT_POST_SCREEN_UPDATE_NONCE_ARG_NAME ),
+			esc_attr( wp_create_nonce( 'set_post_thumbnail-' . $post_id ) )
+		);
+		return $content;
+	}
+
+	/**
+	 * Enqueue edit post scripts.
+	 */
+	public function enqueue_edit_post_scripts() {
+		wp_enqueue_script( 'edit-post-preview-admin-featured-image' );
+	}
+
+	/**
+	 * Sanitize/validate an attachment ID as representing an attachment post ID or -1.
+	 *
+	 * @see sanitize_meta()
+	 *
+	 * @param int $attachment_id Attachment ID.
+	 * @return int|false Attachment ID, -1, or false if failure.
+	 */
+	public function sanitize_value( $attachment_id ) {
+		$attachment_id = intval( $attachment_id );
+		if ( empty( $attachment_id ) || -1 === $attachment_id ) {
+			return -1;
+		}
+		$mime_type = get_post_mime_type( $attachment_id );
+		if ( ! $mime_type || ! preg_match( '#^image/#', $mime_type ) ) {
+			return false;
+		}
+		return $attachment_id;
+	}
+
+	/**
+	 * Sanitize (and validate) an input for a specific setting instance.
+	 *
+	 * @see update_metadata()
+	 *
+	 * @param string                        $attachment_id The value to sanitize.
+	 * @param WP_Customize_Postmeta_Setting $setting       Setting.
+	 * @param bool                          $strict        Whether validation is being done. This is part of the proposed patch in in #34893.
+	 * @return mixed|null Null if an input isn't valid, otherwise the sanitized value.
+	 */
+	public function sanitize_setting( $attachment_id, WP_Customize_Postmeta_Setting $setting, $strict = false ) {
+		unset( $setting );
+
+		/*
+		 * Note that at this point, sanitize_meta() has already been called in WP_Customize_Postmeta_Setting::sanitize(),
+		 * and the meta is registered wit WP_Customize_Featured_Image_Controller::sanitize_value() as the sanitize_callback().
+		 * So $attachment_id is either a valid attachment ID, -1, or false.
+		 */
+		if ( ! is_int( $attachment_id ) ) {
+			if ( $strict ) {
+				return new WP_Error( 'invalid_attachment_id', __( 'The attachment is invalid.', 'customize-posts' ) );
+			} else {
+				return null;
+			}
+		}
+
+		return $attachment_id;
+	}
+
+	/**
+	 * Cast _thumbnail_id postmeta values from string numbers to integers.
+	 *
+	 * @param mixed                         $meta_value The setting value.
+	 * @param WP_Customize_Postmeta_Setting $setting    Setting instance.
+	 *
+	 * @return mixed Formatted value.
+	 */
+	public function js_value( $meta_value, WP_Customize_Postmeta_Setting $setting ) {
+		unset( $setting );
+		$meta_value = intval( $meta_value );
+		if ( $meta_value <= 0 ) {
+			$meta_value = -1;
+		}
+		return $meta_value;
+	}
+}

--- a/php/class-wp-customize-page-template-controller.php
+++ b/php/class-wp-customize-page-template-controller.php
@@ -42,7 +42,7 @@ class WP_Customize_Page_Template_Controller extends WP_Customize_Postmeta_Contro
 	/**
 	 * Enqueue customize scripts.
 	 */
-	public function enqueue_customize_scripts() {
+	public function enqueue_customize_pane_scripts() {
 		$handle = 'customize-page-template';
 		wp_enqueue_script( $handle );
 		$exports = array(

--- a/php/class-wp-customize-page-template-controller.php
+++ b/php/class-wp-customize-page-template-controller.php
@@ -45,19 +45,13 @@ class WP_Customize_Page_Template_Controller extends WP_Customize_Postmeta_Contro
 	public function enqueue_customize_scripts() {
 		$handle = 'customize-page-template';
 		wp_enqueue_script( $handle );
-		wp_add_inline_script( $handle, 'CustomizePageTemplate.init();' );
-
 		$exports = array(
 			'defaultPageTemplateChoices' => $this->get_page_template_choices(),
 			'l10n' => array(
 				'controlLabel' => __( 'Page Template', 'customize-posts' ),
 			),
 		);
-		wp_scripts()->add_data(
-			$handle,
-			'data',
-			sprintf( 'var _wpCustomizePageTemplateExports = %s;', wp_json_encode( $exports ) )
-		);
+		wp_add_inline_script( $handle, sprintf( 'CustomizePageTemplate.init( %s );', wp_json_encode( $exports ) ) );
 	}
 
 	/**

--- a/php/class-wp-customize-post-field-partial.php
+++ b/php/class-wp-customize-post-field-partial.php
@@ -165,13 +165,20 @@ class WP_Customize_Post_Field_Partial extends WP_Customize_Partial {
 			}
 		} elseif ( 'post_author' === $this->field_id ) {
 			if ( 'author-bio' === $this->placement && is_singular() && get_the_author_meta( 'description' ) ) {
-				if ( '' !== locate_template( 'author-bio.php' ) ) {
-					ob_start();
-					get_template_part( 'author-bio' );
-					$rendered = ob_get_contents();
-					ob_end_clean();
-				} else {
-					$rendered = false;
+
+				$rendered = false;
+				$template_parts = array(
+					'template-parts/biography',
+					'author-bio',
+				);
+				foreach ( $template_parts as $template_part ) {
+					if ( '' !== locate_template( $template_part . '.php' ) ) {
+						ob_start();
+						get_template_part( $template_part );
+						$rendered = ob_get_contents();
+						ob_end_clean();
+						break;
+					}
 				}
 			} elseif ( 'byline' === $this->placement && ( is_singular() || is_multi_author() ) ) {
 				$rendered = sprintf( '<a class="url fn n" href="%1$s">%2$s</a>',

--- a/php/class-wp-customize-postmeta-controller.php
+++ b/php/class-wp-customize-postmeta-controller.php
@@ -113,6 +113,7 @@ abstract class WP_Customize_Postmeta_Controller {
 		foreach ( $post_types as $post_type ) {
 			$setting_args = array(
 				'sanitize_callback' => array( $this, 'sanitize_setting' ),
+				'sanitize_js_callback' => array( $this, 'js_value' ),
 				'transport' => $this->setting_transport,
 				'theme_supports' => $this->theme_supports,
 				'default' => $this->default,
@@ -159,6 +160,8 @@ abstract class WP_Customize_Postmeta_Controller {
 	/**
 	 * Sanitize (and validate) an input.
 	 *
+	 * Callback for `customize_sanitize_post_meta_{$meta_key}` filter.
+	 *
 	 * @see update_metadata()
 	 *
 	 * @param string                        $meta_value The value to sanitize.
@@ -168,6 +171,20 @@ abstract class WP_Customize_Postmeta_Controller {
 	 */
 	public function sanitize_setting( $meta_value, WP_Customize_Postmeta_Setting $setting, $strict = false ) {
 		unset( $setting, $strict );
+		return $meta_value;
+	}
+
+	/**
+	 * Callback to format a Customize setting value for use in JavaScript.
+	 *
+	 * Callback for `customize_sanitize_js_post_meta_{$meta_key}` filter.
+	 *
+	 * @param mixed                         $meta_value The setting value.
+	 * @param WP_Customize_Postmeta_Setting $setting    Setting instance.
+	 * @return mixed Formatted value.
+	 */
+	public function js_value( $meta_value, WP_Customize_Postmeta_Setting $setting ) {
+		unset( $setting );
 		return $meta_value;
 	}
 }

--- a/php/class-wp-customize-postmeta-controller.php
+++ b/php/class-wp-customize-postmeta-controller.php
@@ -96,8 +96,9 @@ abstract class WP_Customize_Postmeta_Controller {
 		}
 
 		add_action( 'customize_posts_register_meta', array( $this, 'register_meta' ) );
-		add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue_customize_scripts' ) );
+		add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue_customize_pane_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_scripts' ) );
+		add_action( 'customize_preview_init', array( $this, 'customize_preview_init' ) );
 	}
 
 	/**
@@ -139,9 +140,11 @@ abstract class WP_Customize_Postmeta_Controller {
 	}
 
 	/**
-	 * Enqueue customize scripts.
+	 * Enqueue scripts for Customizer pane (controls).
+	 *
+	 * This would be the scripts for the postmeta Customizer control.
 	 */
-	abstract public function enqueue_customize_scripts();
+	abstract public function enqueue_customize_pane_scripts();
 
 	/**
 	 * Enqueue admin scripts.
@@ -154,8 +157,24 @@ abstract class WP_Customize_Postmeta_Controller {
 
 	/**
 	 * Enqueue edit post scripts.
+	 *
+	 * This would be for receiving updates from the Customizer when making changes in a post preview.
 	 */
 	public function enqueue_edit_post_scripts() {}
+
+	/**
+	 * Initialize Customizer preview.
+	 */
+	public function customize_preview_init() {
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_customize_preview_scripts' ) );
+	}
+
+	/**
+	 * Enqueue scripts for the Customizer preview.
+	 *
+	 * This would enqueue the script for any custom partials.
+	 */
+	public function enqueue_customize_preview_scripts() {}
 
 	/**
 	 * Sanitize a meta value.

--- a/php/class-wp-customize-postmeta-controller.php
+++ b/php/class-wp-customize-postmeta-controller.php
@@ -49,6 +49,13 @@ abstract class WP_Customize_Postmeta_Controller {
 	public $sanitize_callback;
 
 	/**
+	 * Sanitize JS setting value callback (aka JSON export).
+	 *
+	 * @var callable
+	 */
+	public $sanitize_js_callback;
+
+	/**
 	 * Setting transport.
 	 *
 	 * @var string
@@ -79,6 +86,13 @@ abstract class WP_Customize_Postmeta_Controller {
 
 		if ( empty( $this->meta_key ) ) {
 			throw new Exception( 'Missing meta_key' );
+		}
+
+		if ( ! isset( $this->sanitize_callback ) ) {
+			$this->sanitize_callback = array( $this, 'sanitize_setting' );
+		}
+		if ( ! isset( $this->sanitize_js_callback ) ) {
+			$this->sanitize_js_callback = array( $this, 'js_value' );
 		}
 
 		add_action( 'customize_posts_register_meta', array( $this, 'register_meta' ) );
@@ -112,8 +126,8 @@ abstract class WP_Customize_Postmeta_Controller {
 
 		foreach ( $post_types as $post_type ) {
 			$setting_args = array(
-				'sanitize_callback' => array( $this, 'sanitize_setting' ),
-				'sanitize_js_callback' => array( $this, 'js_value' ),
+				'sanitize_callback' => $this->sanitize_callback,
+				'sanitize_js_callback' => $this->sanitize_js_callback,
 				'transport' => $this->setting_transport,
 				'theme_supports' => $this->theme_supports,
 				'default' => $this->default,

--- a/php/class-wp-customize-postmeta-setting.php
+++ b/php/class-wp-customize-postmeta-setting.php
@@ -154,9 +154,6 @@ class WP_Customize_Postmeta_Setting extends WP_Customize_Setting {
 		$meta_key = $this->meta_key;
 		$prev_value = ''; // Plural meta is not supported.
 
-		// @todo How would $strict validation get passed into the sanitize callback?
-		$meta_value = sanitize_meta( $meta_key, $meta_value, $meta_type );
-
 		/**
 		 * Filter a Customize setting value in form.
 		 *
@@ -165,6 +162,11 @@ class WP_Customize_Postmeta_Setting extends WP_Customize_Setting {
 		 * @param bool                 $strict      Whether validation is being done. This is part of the proposed patch in in #34893.
 		 */
 		$meta_value = apply_filters( "customize_sanitize_{$this->id}", $meta_value, $this, $strict );
+
+		// Apply sanitization if value didn't fail validation.
+		if ( ! is_wp_error( $meta_value ) && ! is_null( $meta_value ) ) {
+			$meta_value = sanitize_meta( $meta_key, $meta_value, $meta_type );
+		}
 
 		/** This filter is documented in wp-includes/meta.php */
 		$check = apply_filters( "update_{$meta_type}_metadata", null, $object_id, $meta_key, $meta_value, $prev_value );

--- a/tests/php/test-class-edit-post-preview.php
+++ b/tests/php/test-class-edit-post-preview.php
@@ -154,13 +154,50 @@ class Test_Edit_Post_Preview extends WP_UnitTestCase {
 	 * @see Edit_Post_Preview::enqueue_admin_scripts()
 	 */
 	public function test_enqueue_admin_scripts() {
+		// @codingStandardsIgnoreStart
 		$GLOBALS['post'] = get_post( $this->post_id );
+		// @codingStandardsIgnoreStop
 		set_current_screen( 'post-new.php' );
 
 		$this->preview->enqueue_admin_scripts();
 
 		$this->assertTrue( wp_script_is( 'edit-post-preview-admin', 'enqueued' ) );
 		$this->assertTrue( wp_script_is( 'customize-loader', 'enqueued' ) );
+	}
+
+	/**
+	 * Test remove_static_controls_and_sections().
+	 *
+	 * @see Edit_Post_Preview::remove_static_controls_and_sections()
+	 */
+	public function test_remove_static_controls_and_sections() {
+		global $wp_customize;
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		require_once( ABSPATH . WPINC . '/class-wp-customize-manager.php' );
+		// @codingStandardsIgnoreStart
+		$wp_customize = new WP_Customize_Manager();
+		// @codingStandardsIgnoreStop
+
+		$this->assertEmpty( $wp_customize->sections() );
+		$this->assertEmpty( $wp_customize->controls() );
+		$wp_customize->register_controls();
+		$this->assertNotEmpty( $wp_customize->sections() );
+		$this->assertNotEmpty( $wp_customize->controls() );
+		$this->preview->remove_static_controls_and_sections();
+		$this->assertNotEmpty( $wp_customize->sections() );
+		$this->assertNotEmpty( $wp_customize->controls() );
+
+		$_GET['previewed_post'] = 123;
+		$_REQUEST['customize_preview_post_nonce'] = wp_create_nonce( 'customize_preview_post' );
+		$this->preview->remove_static_controls_and_sections();
+		$this->assertEmpty( $wp_customize->sections() );
+		$this->assertEmpty( $wp_customize->controls() );
+
+		// @codingStandardsIgnoreStart
+		$wp_customize = null;
+		// @codingStandardsIgnoreStop
+		$this->preview->remove_static_controls_and_sections();
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-featured-image-controller.php
+++ b/tests/php/test-class-wp-customize-featured-image-controller.php
@@ -64,20 +64,20 @@ class Test_WP_Customize_Featured_Image_Controller extends WP_UnitTestCase {
 		$this->assertEquals( '_thumbnail_id', $controller->meta_key );
 		$this->assertEquals( 'thumbnail', $controller->post_type_supports );
 		$this->assertEquals( 'postMessage', $controller->setting_transport );
-		$this->assertEquals( -1, $controller->default );
+		$this->assertEquals( '', $controller->default );
 		$this->assertEquals( 10, has_action( 'customize_register', array( $controller, 'setup_selective_refresh' ) ) );
 	}
 
 	/**
 	 * Test enqueue_customize_scripts().
 	 *
-	 * @see WP_Customize_Featured_Image_Controller::enqueue_customize_scripts()
+	 * @see WP_Customize_Featured_Image_Controller::enqueue_customize_pane_scripts()
 	 */
 	public function test_enqueue_customize_scripts() {
 		$handle = 'customize-featured-image';
 		$controller = new WP_Customize_Featured_Image_Controller();
 		$this->assertFalse( wp_script_is( $handle, 'enqueued' ) );
-		$controller->enqueue_customize_scripts();
+		$controller->enqueue_customize_pane_scripts();
 		$this->assertTrue( wp_script_is( $handle, 'enqueued' ) );
 
 		$data = wp_scripts()->get_data( $handle, 'after' );
@@ -122,14 +122,6 @@ class Test_WP_Customize_Featured_Image_Controller extends WP_UnitTestCase {
 		$_REQUEST['_wpnonce'] = wp_create_nonce( "set_post_thumbnail-$post_id" );
 		$_POST['post_id'] = $post_id;
 		add_filter( 'wp_die_handler', array( $this, 'die_handler_test_handle_ajax_set_post_thumbnail' ) );
-
-		$_POST['thumbnail_id'] = $post_id;
-		$controller->handle_ajax_set_post_thumbnail();
-		$this->assertContains( 'The chosen image will not persist until you save', $this->die_args[0] );
-		$this->assertContains( 'Invalid attachment selected', $this->die_args[0] );
-		$this->assertContains( 'set_post_thumbnail_nonce', $this->die_args[0] );
-		$this->assertNotContains( 'Remove featured image', $this->die_args[0] );
-		$this->die_args = array();
 
 		$_POST['thumbnail_id'] = $attachment_id;
 		$controller->handle_ajax_set_post_thumbnail();
@@ -279,9 +271,9 @@ class Test_WP_Customize_Featured_Image_Controller extends WP_UnitTestCase {
 		) );
 		$post_id = $this->factory()->post->create();
 		$this->assertEquals( $attachment_id, $controller->sanitize_value( (string) $attachment_id ) );
-		$this->assertEquals( -1, $controller->sanitize_value( '' ) );
-		$this->assertFalse( $controller->sanitize_value( -123 ) );
-		$this->assertFalse( $controller->sanitize_value( $post_id ) );
+		$this->assertEquals( '', $controller->sanitize_value( -1 ) );
+		$this->assertEquals( '', $controller->sanitize_value( -123 ) );
+		$this->assertEquals( '', $controller->sanitize_value( $post_id ) );
 	}
 
 	/**
@@ -295,10 +287,15 @@ class Test_WP_Customize_Featured_Image_Controller extends WP_UnitTestCase {
 		$setting_id = WP_Customize_Postmeta_Setting::get_post_meta_setting_id( $post, $controller->meta_key );
 		$setting = new WP_Customize_Postmeta_Setting( $this->wp_customize, $setting_id );
 
-		$this->assertNull( $controller->sanitize_setting( 'bad', $setting, false ) );
+		$this->assertEquals( '', $controller->sanitize_setting( 'bad', $setting, false ) );
 		$this->assertInstanceOf( 'WP_Error', $controller->sanitize_setting( 'bad', $setting, true ) );
 	}
 
+	/**
+	 * Test sanitize_setting().
+	 *
+	 * @see WP_Customize_Featured_Image_Controller::js_value()
+	 */
 	public function test_js_value() {
 		$controller = new WP_Customize_Featured_Image_Controller();
 		$post = get_post( $this->factory()->post->create() );
@@ -306,7 +303,7 @@ class Test_WP_Customize_Featured_Image_Controller extends WP_UnitTestCase {
 		$setting = new WP_Customize_Postmeta_Setting( $this->wp_customize, $setting_id );
 
 		$this->assertEquals( 1, $controller->js_value( '1', $setting ) );
-		$this->assertEquals( -1, $controller->js_value( '0', $setting ) );
-		$this->assertEquals( -1, $controller->js_value( -123, $setting ) );
+		$this->assertEquals( '', $controller->js_value( '0', $setting ) );
+		$this->assertEquals( '', $controller->js_value( -123, $setting ) );
 	}
 }

--- a/tests/php/test-class-wp-customize-featured-image-controller.php
+++ b/tests/php/test-class-wp-customize-featured-image-controller.php
@@ -1,0 +1,312 @@
+<?php
+/**
+ * Tests for WP_Customize_Featured_Image_Controller
+ *
+ * @package WordPress
+ * @subpackage Customize
+ */
+
+/**
+ * Class Test_WP_Customize_Featured_Image_Controller
+ */
+class Test_WP_Customize_Featured_Image_Controller extends WP_UnitTestCase {
+
+	/**
+	 * Manager.
+	 *
+	 * @var WP_Customize_Manager
+	 */
+	protected $wp_customize;
+
+	/**
+	 * User ID.
+	 *
+	 * @var int
+	 */
+	protected $user_id;
+
+	/**
+	 * Setup.
+	 *
+	 * @inheritdoc
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->user_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $this->user_id );
+
+		require_once( ABSPATH . WPINC . '/class-wp-customize-manager.php' );
+		// @codingStandardsIgnoreStart
+		$GLOBALS['wp_customize'] = new WP_Customize_Manager();
+		// @codingStandardsIgnoreStop
+		$this->wp_customize = $GLOBALS['wp_customize'];
+	}
+
+	/**
+	 * Teardown.
+	 *
+	 * @inheritdoc
+	 */
+	function tearDown() {
+		$this->wp_customize = null;
+		unset( $_POST['customized'] );
+		unset( $GLOBALS['wp_customize'] );
+		parent::tearDown();
+	}
+
+	/**
+	 * Test construct().
+	 *
+	 * @see WP_Customize_Postmeta_Controller::__construct()
+	 */
+	public function test_construct() {
+		$controller = new WP_Customize_Featured_Image_Controller();
+		$this->assertEquals( '_thumbnail_id', $controller->meta_key );
+		$this->assertEquals( 'thumbnail', $controller->post_type_supports );
+		$this->assertEquals( 'postMessage', $controller->setting_transport );
+		$this->assertEquals( -1, $controller->default );
+		$this->assertEquals( 10, has_action( 'customize_register', array( $controller, 'setup_selective_refresh' ) ) );
+	}
+
+	/**
+	 * Test enqueue_customize_scripts().
+	 *
+	 * @see WP_Customize_Featured_Image_Controller::enqueue_customize_scripts()
+	 */
+	public function test_enqueue_customize_scripts() {
+		$handle = 'customize-featured-image';
+		$controller = new WP_Customize_Featured_Image_Controller();
+		$this->assertFalse( wp_script_is( $handle, 'enqueued' ) );
+		$controller->enqueue_customize_scripts();
+		$this->assertTrue( wp_script_is( $handle, 'enqueued' ) );
+
+		$data = wp_scripts()->get_data( $handle, 'after' );
+		$this->assertNotEmpty( preg_match( '/({.*})/', join( '', $data ), $matches ) );
+		$exported = json_decode( $matches[1], true );
+		$this->assertInternalType( 'array', $exported );
+		$this->assertArrayHasKey( 'l10n', $exported );
+		$this->assertArrayHasKey( 'default_button_labels', $exported['l10n'] );
+
+		$after = wp_scripts()->get_data( $handle, 'after' );
+		$this->assertInternalType( 'array', $after );
+		$this->assertContains( 'CustomizeFeaturedImage.init(', array_pop( $after ) );
+	}
+
+	/**
+	 * Test override_default_edit_post_screen_functionality().
+	 *
+	 * @see WP_Customize_Featured_Image_Controller::override_default_edit_post_screen_functionality()
+	 */
+	public function test_override_default_edit_post_screen_functionality() {
+		$controller = new WP_Customize_Featured_Image_Controller();
+		$controller->override_default_edit_post_screen_functionality();
+		$this->assertEquals( 0, has_action( 'wp_ajax_set-post-thumbnail', array( $controller, 'handle_ajax_set_post_thumbnail' ) ) );
+		$this->assertEquals( 10, has_filter( 'admin_post_thumbnail_html', array( $controller, 'filter_admin_post_thumbnail_html' ) ) );
+		$this->assertEquals( 10, has_action( 'save_post', array( $controller, 'handle_save_post_thumbnail_id' ) ) );
+	}
+
+	/**
+	 * Test handle_ajax_set_post_thumbnail().
+	 *
+	 * @see WP_Customize_Featured_Image_Controller::handle_ajax_set_post_thumbnail()
+	 * @see WP_Customize_Featured_Image_Controller::filter_admin_post_thumbnail_html()
+	 */
+	public function test_handle_ajax_set_post_thumbnail() {
+		$controller = new WP_Customize_Featured_Image_Controller();
+		$controller->override_default_edit_post_screen_functionality();
+
+		$post_id = $this->factory()->post->create();
+		$attachment_id = $this->factory()->attachment->create_object( 'foo.jpg', 0, array(
+			'post_mime_type' => 'image/jpeg'
+		) );
+		$_REQUEST['_wpnonce'] = wp_create_nonce( "set_post_thumbnail-$post_id" );
+		$_POST['post_id'] = $post_id;
+		add_filter( 'wp_die_handler', array( $this, 'die_handler_test_handle_ajax_set_post_thumbnail' ) );
+
+		$_POST['thumbnail_id'] = $post_id;
+		$controller->handle_ajax_set_post_thumbnail();
+		$this->assertContains( 'The chosen image will not persist until you save', $this->die_args[0] );
+		$this->assertContains( 'Invalid attachment selected', $this->die_args[0] );
+		$this->assertContains( 'set_post_thumbnail_nonce', $this->die_args[0] );
+		$this->assertNotContains( 'Remove featured image', $this->die_args[0] );
+		$this->die_args = array();
+
+		$_POST['thumbnail_id'] = $attachment_id;
+		$controller->handle_ajax_set_post_thumbnail();
+		$this->assertContains( 'The chosen image will not persist until you save', $this->die_args[0] );
+		$this->assertNotContains( 'Invalid attachment selected', $this->die_args[0] );
+		$this->assertContains( 'set_post_thumbnail_nonce', $this->die_args[0] );
+		$this->assertContains( 'Remove featured image', $this->die_args[0] );
+		$this->die_args = array();
+
+		$_POST['thumbnail_id'] = -1;
+		$controller->handle_ajax_set_post_thumbnail();
+		$this->assertNotContains( 'Remove featured image', $this->die_args[0] );
+		$this->assertContains( 'Set featured image', $this->die_args[0] );
+		$this->assertContains( 'set_post_thumbnail_nonce', $this->die_args[0] );
+		$this->die_args = array();
+	}
+
+	protected $die_args = array();
+
+	/**
+	 * Get die handler.
+	 *
+	 * @return callable
+	 */
+	public function die_handler_test_handle_ajax_set_post_thumbnail() {
+		return array( $this, 'die_test_handle_ajax_set_post_thumbnail' );
+	}
+
+	/**
+	 * Handle die.
+	 */
+	public function die_test_handle_ajax_set_post_thumbnail() {
+		$this->die_args = func_get_args();
+	}
+
+	/**
+	 * Test handle_save_post_thumbnail_id().
+	 *
+	 * @see WP_Customize_Featured_Image_Controller::handle_save_post_thumbnail_id()
+	 */
+	public function test_handle_save_post_thumbnail_id() {
+		$controller = new WP_Customize_Featured_Image_Controller();
+		$controller->override_default_edit_post_screen_functionality();
+
+		$post_id = $this->factory()->post->create();
+		$attachment_id = $this->factory()->attachment->create_object( 'foo.jpg', 0, array(
+			'post_mime_type' => 'image/jpeg'
+		) );
+
+		wp_set_current_user( 0 );
+		$_REQUEST[ WP_Customize_Featured_Image_Controller::EDIT_POST_SCREEN_UPDATE_NONCE_ARG_NAME ] = wp_create_nonce( 'set_post_thumbnail-' . $post_id );
+		$this->assertFalse( $controller->handle_save_post_thumbnail_id( $post_id ) );
+
+		wp_set_current_user( $this->user_id );
+		$_REQUEST[ WP_Customize_Featured_Image_Controller::EDIT_POST_SCREEN_UPDATE_NONCE_ARG_NAME ] = wp_create_nonce( 'set_post_thumbnail-' . $post_id );
+		$this->assertFalse( $controller->handle_save_post_thumbnail_id( $post_id ) );
+
+		$_POST[ $controller->meta_key ] = $attachment_id;
+		$this->assertTrue( $controller->handle_save_post_thumbnail_id( $post_id ) );
+		$this->assertEquals( $attachment_id, get_post_thumbnail_id( $post_id ) );
+
+		$_POST[ $controller->meta_key ] = -1;
+		$this->assertTrue( $controller->handle_save_post_thumbnail_id( $post_id ) );
+		$this->assertEquals( '', get_post_thumbnail_id( $post_id ) );
+	}
+
+	/**
+	 * Test setup_selective_refresh().
+	 *
+	 * @see WP_Customize_Featured_Image_Controller::setup_selective_refresh()
+	 */
+	public function test_setup_selective_refresh() {
+		$controller = new WP_Customize_Featured_Image_Controller();
+		$controller->setup_selective_refresh();
+		$this->assertEquals( 10, has_filter( 'post_thumbnail_html', array( $controller, 'filter_post_thumbnail_html' ) ) );
+		$this->assertEquals( 10, has_action( 'wp_footer', array( $controller, 'add_partials' ) ) );
+		$this->assertEquals( 10, has_filter( 'customize_dynamic_partial_args', array( $controller, 'filter_customize_dynamic_partial_args' ) ) );
+	}
+
+	/**
+	 * Test add_partials().
+	 *
+	 * @see WP_Customize_Featured_Image_Controller::add_partials()
+	 * @see WP_Customize_Featured_Image_Controller::filter_customize_dynamic_partial_args()
+	 * @see WP_Customize_Featured_Image_Controller::filter_post_thumbnail_html()
+	 */
+	public function test_add_partials() {
+		$controller = new WP_Customize_Featured_Image_Controller();
+		$controller->setup_selective_refresh();
+		$this->assertInternalType( 'array', $controller->add_partials() );
+		$this->assertEmpty( $controller->add_partials() );
+
+		$post = get_post( $this->factory()->post->create() );
+		$attachment_id = $this->factory()->attachment->create_object( 'foo.jpg', 0, array(
+			'post_mime_type' => 'image/jpeg'
+		) );
+
+		$setting_id = WP_Customize_Postmeta_Setting::get_post_meta_setting_id( $post, $controller->meta_key );
+		$setting = new WP_Customize_Postmeta_Setting( $this->wp_customize, $setting_id );
+		$this->wp_customize->add_setting( $setting );
+		$partials = $controller->add_partials();
+		$this->assertCount( 1, $partials );
+
+		$partial = array_shift( $partials );
+		$this->assertInstanceOf( 'WP_Customize_Partial', $partial );
+		$this->assertEquals( $setting_id, $partial->id );
+		$this->assertEquals( array( $setting_id ), $partial->settings );
+		$this->assertEquals( array( $controller, 'render_post_thumbnail_partial' ), $partial->render_callback );
+		$this->assertTrue( $partial->container_inclusive );
+		$this->assertEquals( '[data-customize-partial-id="' . $partial->id . '"]', $partial->selector );
+
+		$html = get_the_post_thumbnail( $post->ID );
+		$this->assertEquals( '', $html );
+
+		set_post_thumbnail( $post->ID, $attachment_id );
+		$html = get_the_post_thumbnail( $post->ID );
+		$this->assertContains( sprintf( 'data-customize-partial-id="%s"', $partial->id ), $html );
+		$this->assertContains( 'data-customize-partial-placement-context', $html );
+
+		$partial_html = $controller->render_post_thumbnail_partial( $partial, array() );
+		$this->assertEquals( $partial_html, $html );
+	}
+
+	/**
+	 * Test enqueue_edit_post_scripts().
+	 *
+	 * @see WP_Customize_Featured_Image_Controller::enqueue_admin_scripts()
+	 * @see WP_Customize_Featured_Image_Controller::enqueue_edit_post_scripts()
+	 */
+	public function test_enqueue_edit_post_scripts() {
+		$handle = 'edit-post-preview-admin-featured-image';
+		$controller = new WP_Customize_Featured_Image_Controller();
+		$this->assertFalse( wp_script_is( $handle, 'enqueued' ) );
+		$controller->enqueue_edit_post_scripts();
+		$this->assertTrue( wp_script_is( $handle, 'enqueued' ) );
+	}
+
+	/**
+	 * Test sanitize_value().
+	 *
+	 * @see WP_Customize_Featured_Image_Controller::sanitize_value()
+	 */
+	public function test_sanitize_value() {
+		$controller = new WP_Customize_Featured_Image_Controller();
+		$attachment_id = $this->factory()->attachment->create_object( 'foo.jpg', 0, array(
+			'post_mime_type' => 'image/jpeg'
+		) );
+		$post_id = $this->factory()->post->create();
+		$this->assertEquals( $attachment_id, $controller->sanitize_value( (string) $attachment_id ) );
+		$this->assertEquals( -1, $controller->sanitize_value( '' ) );
+		$this->assertFalse( $controller->sanitize_value( -123 ) );
+		$this->assertFalse( $controller->sanitize_value( $post_id ) );
+	}
+
+	/**
+	 * Test sanitize_setting().
+	 *
+	 * @see WP_Customize_Featured_Image_Controller::sanitize_setting()
+	 */
+	public function test_sanitize_setting() {
+		$controller = new WP_Customize_Featured_Image_Controller();
+		$post = get_post( $this->factory()->post->create() );
+		$setting_id = WP_Customize_Postmeta_Setting::get_post_meta_setting_id( $post, $controller->meta_key );
+		$setting = new WP_Customize_Postmeta_Setting( $this->wp_customize, $setting_id );
+
+		$this->assertNull( $controller->sanitize_setting( 'bad', $setting, false ) );
+		$this->assertInstanceOf( 'WP_Error', $controller->sanitize_setting( 'bad', $setting, true ) );
+	}
+
+	public function test_js_value() {
+		$controller = new WP_Customize_Featured_Image_Controller();
+		$post = get_post( $this->factory()->post->create() );
+		$setting_id = WP_Customize_Postmeta_Setting::get_post_meta_setting_id( $post, $controller->meta_key );
+		$setting = new WP_Customize_Postmeta_Setting( $this->wp_customize, $setting_id );
+
+		$this->assertEquals( 1, $controller->js_value( '1', $setting ) );
+		$this->assertEquals( -1, $controller->js_value( '0', $setting ) );
+		$this->assertEquals( -1, $controller->js_value( -123, $setting ) );
+	}
+}

--- a/tests/php/test-class-wp-customize-featured-image-controller.php
+++ b/tests/php/test-class-wp-customize-featured-image-controller.php
@@ -69,11 +69,11 @@ class Test_WP_Customize_Featured_Image_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test enqueue_customize_scripts().
+	 * Test enqueue_customize_pane_scripts().
 	 *
 	 * @see WP_Customize_Featured_Image_Controller::enqueue_customize_pane_scripts()
 	 */
-	public function test_enqueue_customize_scripts() {
+	public function test_enqueue_customize_pane_scripts() {
 		$handle = 'customize-featured-image';
 		$controller = new WP_Customize_Featured_Image_Controller();
 		$this->assertFalse( wp_script_is( $handle, 'enqueued' ) );
@@ -90,6 +90,23 @@ class Test_WP_Customize_Featured_Image_Controller extends WP_UnitTestCase {
 		$after = wp_scripts()->get_data( $handle, 'after' );
 		$this->assertInternalType( 'array', $after );
 		$this->assertContains( 'CustomizeFeaturedImage.init(', array_pop( $after ) );
+	}
+
+	/**
+	 * Test enqueue_customize_preview_scripts().
+	 *
+	 * @see WP_Customize_Featured_Image_Controller::enqueue_customize_preview_scripts()
+	 */
+	public function test_enqueue_customize_preview_scripts() {
+		$handle = 'customize-preview-featured-image';
+		$controller = new WP_Customize_Featured_Image_Controller();
+		$this->assertFalse( wp_script_is( $handle, 'enqueued' ) );
+		$controller->enqueue_customize_preview_scripts();
+		$this->assertTrue( wp_script_is( $handle, 'enqueued' ) );
+
+		$after = wp_scripts()->get_data( $handle, 'after' );
+		$this->assertInternalType( 'array', $after );
+		$this->assertContains( 'CustomizePreviewFeaturedImage.init(', array_pop( $after ) );
 	}
 
 	/**
@@ -243,6 +260,34 @@ class Test_WP_Customize_Featured_Image_Controller extends WP_UnitTestCase {
 
 		$partial_html = $controller->render_post_thumbnail_partial( $partial, array() );
 		$this->assertEquals( $partial_html, $html );
+	}
+
+	/**
+	 * Test add_partials() without Customizer.
+	 *
+	 * @see WP_Customize_Featured_Image_Controller::add_partials()
+	 */
+	public function test_add_partials_without_customize() {
+		$controller = new WP_Customize_Featured_Image_Controller();
+		$GLOBALS['wp_customize'] = null;
+		$partials = $controller->add_partials();
+		$this->assertInternalType( 'array', $partials );
+		$this->assertCount( 0, $partials );
+	}
+
+	/**
+	 * See filter_customize_dynamic_partial_args().
+	 *
+	 * @see WP_Customize_Featured_Image_Controller::filter_customize_dynamic_partial_args()
+	 */
+	public function test_filter_customize_dynamic_partial_args() {
+		$controller = new WP_Customize_Featured_Image_Controller();
+		$post = get_post( $this->factory()->post->create() );
+		$setting_id = WP_Customize_Postmeta_Setting::get_post_meta_setting_id( $post, $controller->meta_key );
+		$args = $controller->filter_customize_dynamic_partial_args( false, $setting_id );
+		$this->assertInternalType( 'array', $args );
+
+		$this->assertFalse( $controller->filter_customize_dynamic_partial_args( false, 'unknown' ) );
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-page-template-controller.php
+++ b/tests/php/test-class-wp-customize-page-template-controller.php
@@ -79,8 +79,8 @@ class Test_WP_Customize_Page_Template_Controller extends WP_UnitTestCase {
 		$controller->enqueue_customize_scripts();
 		$this->assertTrue( wp_script_is( $handle, 'enqueued' ) );
 
-		$data = wp_scripts()->get_data( $handle, 'data' );
-		$this->assertNotEmpty( preg_match( '/var _wpCustomizePageTemplateExports = ({.*});/',  $data, $matches ) );
+		$data = wp_scripts()->get_data( $handle, 'after' );
+		$this->assertNotEmpty( preg_match( '/({.*})/', join( '', $data ), $matches ) );
 		$exported = json_decode( $matches[1], true );
 		$this->assertInternalType( 'array', $exported );
 		$this->assertArrayHasKey( 'defaultPageTemplateChoices', $exported );
@@ -89,7 +89,7 @@ class Test_WP_Customize_Page_Template_Controller extends WP_UnitTestCase {
 
 		$after = wp_scripts()->get_data( $handle, 'after' );
 		$this->assertInternalType( 'array', $after );
-		$this->assertContains( 'CustomizePageTemplate.init()', array_pop( $after ) );
+		$this->assertContains( 'CustomizePageTemplate.init(', array_pop( $after ) );
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-page-template-controller.php
+++ b/tests/php/test-class-wp-customize-page-template-controller.php
@@ -147,10 +147,10 @@ class Test_WP_Customize_Page_Template_Controller extends WP_UnitTestCase {
 		$setting = new WP_Customize_Postmeta_Setting( $this->wp_customize, $setting_id );
 
 		$value = 'default';
-		$this->assertEquals( $value, $controller->sanitize_setting( $value, $setting ), false );
+		$this->assertEquals( $value, $controller->sanitize_setting( $value, $setting, false ) );
 
 		$value = 'page-templates/full-width.php';
-		$this->assertEquals( $value, $controller->sanitize_setting( $value, $setting ), false );
+		$this->assertEquals( $value, $controller->sanitize_setting( $value, $setting, false ) );
 
 		$value = '../page-templates/bad.php';
 		$this->assertNull( $controller->sanitize_setting( $value, $setting, false ) );

--- a/tests/php/test-class-wp-customize-page-template-controller.php
+++ b/tests/php/test-class-wp-customize-page-template-controller.php
@@ -72,13 +72,13 @@ class Test_WP_Customize_Page_Template_Controller extends WP_UnitTestCase {
 	/**
 	 * Test enqueue_customize_scripts().
 	 *
-	 * @see WP_Customize_Page_Template_Controller::enqueue_customize_scripts()
+	 * @see WP_Customize_Page_Template_Controller::enqueue_customize_pane_scripts()
 	 */
 	public function test_enqueue_customize_scripts() {
 		$handle = 'customize-page-template';
 		$controller = new WP_Customize_Page_Template_Controller();
 		$this->assertFalse( wp_script_is( $handle, 'enqueued' ) );
-		$controller->enqueue_customize_scripts();
+		$controller->enqueue_customize_pane_scripts();
 		$this->assertTrue( wp_script_is( $handle, 'enqueued' ) );
 
 		$data = wp_scripts()->get_data( $handle, 'after' );

--- a/tests/php/test-class-wp-customize-postmeta-controller.php
+++ b/tests/php/test-class-wp-customize-postmeta-controller.php
@@ -85,7 +85,8 @@ class Test_WP_Customize_Postmeta_Controller extends WP_UnitTestCase {
 		$this->assertNull( $stub->theme_supports );
 		$this->assertEmpty( $stub->post_types );
 		$this->assertNull( $stub->post_type_supports );
-		$this->assertNull( $stub->sanitize_callback );
+		$this->assertEquals( array( $stub, 'sanitize_setting' ), $stub->sanitize_callback );
+		$this->assertEquals( array( $stub, 'js_value' ), $stub->sanitize_js_callback );
 		$this->assertEquals( 'postMessage', $stub->setting_transport );
 		$this->assertEquals( '', $stub->default );
 	}
@@ -102,6 +103,7 @@ class Test_WP_Customize_Postmeta_Controller extends WP_UnitTestCase {
 			'post_types' => array( 'post', 'page' ),
 			'post_type_supports' => 'editor',
 			'sanitize_callback' => 'sanitize_text_field',
+			'sanitize_js_callback' => 'intval',
 			'setting_transport' => 'refresh',
 			'default' => 'Hello world!',
 		);
@@ -217,9 +219,10 @@ class Test_WP_Customize_Postmeta_Controller extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test sanitize_setting().
+	 * Test sanitize_setting() and js_value().
 	 *
 	 * @see WP_Customize_Postmeta_Controller::sanitize_setting()
+	 * @see WP_Customize_Postmeta_Controller::js_value()
 	 */
 	public function test_sanitize_setting() {
 		$args = array(
@@ -236,6 +239,7 @@ class Test_WP_Customize_Postmeta_Controller extends WP_UnitTestCase {
 		$values = array( 'hi', 123, array( 'foo' => 'bar' ) );
 		foreach( $values as $value ) {
 			$this->assertEquals( $value, $stub->sanitize_setting( $value, $setting ) );
+			$this->assertEquals( $value, $stub->js_value( $value, $setting ) );
 		}
 	}
 }

--- a/tests/php/test-class-wp-customize-postmeta-controller.php
+++ b/tests/php/test-class-wp-customize-postmeta-controller.php
@@ -201,6 +201,24 @@ class Test_WP_Customize_Postmeta_Controller extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test register_meta().
+	 *
+	 * @see WP_Customize_Postmeta_Controller::enqueue_admin_scripts()
+	 */
+	public function test_enqueue_admin_scripts() {
+		$args = array(
+			'meta_key' => 'foo',
+			'post_types' => array( 'post', 'page' ),
+			'post_type_supports' => 'editor',
+		);
+		/** @var WP_Customize_Postmeta_Controller $stub */
+		$stub = $this->getMockForAbstractClass( 'WP_Customize_Postmeta_Controller', array( $args ) );
+
+		// @todo Set the current screen to post, and check that it gets called.
+		$stub->enqueue_admin_scripts();
+	}
+
+	/**
 	 * Test sanitize_value().
 	 *
 	 * @see WP_Customize_Postmeta_Controller::sanitize_value()

--- a/tests/php/test-class-wp-customize-postmeta-controller.php
+++ b/tests/php/test-class-wp-customize-postmeta-controller.php
@@ -115,7 +115,7 @@ class Test_WP_Customize_Postmeta_Controller extends WP_UnitTestCase {
 		}
 
 		$this->assertEquals( 10, has_action( 'customize_posts_register_meta', array( $stub, 'register_meta' ) ) );
-		$this->assertEquals( 10, has_action( 'customize_controls_enqueue_scripts', array( $stub, 'enqueue_customize_scripts' ) ) );
+		$this->assertEquals( 10, has_action( 'customize_controls_enqueue_scripts', array( $stub, 'enqueue_customize_pane_scripts' ) ) );
 		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', array( $stub, 'enqueue_admin_scripts' ) ) );
 	}
 

--- a/tests/php/test-class-wp-customize-postmeta-controller.php
+++ b/tests/php/test-class-wp-customize-postmeta-controller.php
@@ -117,6 +117,21 @@ class Test_WP_Customize_Postmeta_Controller extends WP_UnitTestCase {
 		$this->assertEquals( 10, has_action( 'customize_posts_register_meta', array( $stub, 'register_meta' ) ) );
 		$this->assertEquals( 10, has_action( 'customize_controls_enqueue_scripts', array( $stub, 'enqueue_customize_pane_scripts' ) ) );
 		$this->assertEquals( 10, has_action( 'admin_enqueue_scripts', array( $stub, 'enqueue_admin_scripts' ) ) );
+		$this->assertEquals( 10, has_action( 'customize_preview_init', array( $stub, 'customize_preview_init' ) ) );
+	}
+
+	/**
+	 * Test customize_preview_init().
+	 *
+	 * @see WP_Customize_Postmeta_Controller::customize_preview_init()
+	 */
+	public function test_customize_preview_init() {
+		$args = array( 'meta_key' => 'foo' );
+		/** @var WP_Customize_Postmeta_Controller $stub */
+		$stub = $this->getMockForAbstractClass( 'WP_Customize_Postmeta_Controller', array( $args ) );
+		$this->assertFalse( has_action( 'wp_enqueue_scripts', array( $stub, 'enqueue_customize_preview_scripts' ) ) );
+		$stub->customize_preview_init();
+		$this->assertEquals( 10, has_action( 'wp_enqueue_scripts', array( $stub, 'enqueue_customize_preview_scripts' ) ) );
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-posts-preview.php
+++ b/tests/php/test-class-wp-customize-posts-preview.php
@@ -449,6 +449,7 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 		$preview = $this->posts_component->preview;
 		$post_setting_id = WP_Customize_Post_Setting::get_post_setting_id( get_post( $this->post_id ) );
 		$postmeta_setting_id = WP_Customize_Postmeta_Setting::get_post_meta_setting_id( get_post( $this->post_id ), 'foo' );
+		$preview->customize_preview_init();
 		query_posts( 'p=' . $this->post_id );
 		update_post_meta( $this->post_id, 'foo', 'bar' );
 		$this->posts_component->register_post_type_meta( 'post', 'foo' );


### PR DESCRIPTION
Fixes #57.

- [x] Create a new setting representing the `_thumbnail_id` postmeta.
- [x] Create partial for rendering a featured image.
- [x] Add a `post_thumbnail_html` filter to inject the necessary class name for the partial `selector` to match.