### PR TITLE
Define text_domain for i18n sniff

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -55,38 +55,6 @@ module.exports = function( grunt ) {
 			}
 		},
 
-		// Check textdomain errors.
-		checktextdomain: {
-			options:{
-				text_domain: '<%= pkg.name %>',
-				keywords: [
-					'__:1,2d',
-					'_e:1,2d',
-					'_x:1,2c,3d',
-					'esc_html__:1,2d',
-					'esc_html_e:1,2d',
-					'esc_html_x:1,2c,3d',
-					'esc_attr__:1,2d',
-					'esc_attr_e:1,2d',
-					'esc_attr_x:1,2c,3d',
-					'_ex:1,2c,3d',
-					'_n:1,2,4d',
-					'_nx:1,2,4c,5d',
-					'_n_noop:1,2,3d',
-					'_nx_noop:1,2,3c,4d'
-				]
-			},
-			files: {
-				src:	[
-					'**/*.php', // Include all files
-					'!build/**', // Exclude build/
-					'!node_modules/**', // Exclude node_modules/
-					'!tests/**' // Exclude tests/
-				],
-				expand: true
-			}
-		},
-
 		// Build a deploy-able plugin
 		copy: {
 			build: {
@@ -146,7 +114,6 @@ module.exports = function( grunt ) {
 	} );
 
 	// Load tasks
-	grunt.loadNpmTasks( 'grunt-checktextdomain' );
 	grunt.loadNpmTasks( 'grunt-contrib-clean' );
 	grunt.loadNpmTasks( 'grunt-contrib-copy' );
 	grunt.loadNpmTasks( 'grunt-contrib-cssmin' );
@@ -159,8 +126,7 @@ module.exports = function( grunt ) {
 	grunt.registerTask( 'default', [
 		'jshint',
 		'uglify',
-		'cssmin',
-		'checktextdomain'
+		'cssmin'
 	] );
 
 	grunt.registerTask( 'readme', [

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -2,6 +2,11 @@
 <ruleset name="Customize Posts Plugin">
 
 	<rule ref="WordPress-Core" />
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" value="customize-posts" />
+		</properties>
+	</rule>
 	<rule ref="WordPress-Docs" />
 
 	<rule ref="Squiz.Commenting.FunctionComment.ScalarTypeHintMissing">


### PR DESCRIPTION
Depends on https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/pull/560

With this we can get rid of `grunt-checktextdomain`.
