### PR TITLE
Fix JS error

### DIFF
--- a/css/customize-posts.css
+++ b/css/customize-posts.css
@@ -94,3 +94,9 @@ body.mce-fullscreen.customize-posts-content-editor-pane-open div.mce-fullscreen 
 .wp-customizer .mce-tooltip {
 	z-index: 500100 !important; /* originally 100100, but z-index of .wp-full-overlay is 500000 */
 }
+
+@media screen and ( max-width: 782px ) {
+	body.customize-posts-content-editor-pane-open #customize-theme-controls [id^=accordion-panel-posts] ul.accordion-section-content {
+		padding-bottom: 300px;
+	}
+}

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -168,7 +168,6 @@ class Customize_Posts_Plugin {
 			'customize-post-section',
 			'customize-dynamic-control',
 			'underscore',
-			'autosave',
 		);
 		if ( version_compare( str_replace( array( '-src' ), '', $GLOBALS['wp_version'] ), '4.6-beta1', '<' ) ) {
 			$deps[] = 'customize-controls-patched-36521';

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -168,6 +168,7 @@ class Customize_Posts_Plugin {
 			'customize-post-section',
 			'customize-dynamic-control',
 			'underscore',
+			'autosave',
 		);
 		if ( version_compare( str_replace( array( '-src' ), '', $GLOBALS['wp_version'] ), '4.6-beta1', '<' ) ) {
 			$deps[] = 'customize-controls-patched-36521';


### PR DESCRIPTION
By adding `autosave` as a dependency to the `customize-posts` JS the editor tabs and media button becomes functional again.

This suppresses `customize.php?return=%2Fwp-admin%2Fprofile.php:4243Uncaught TypeError: Cannot read property 'interval' of undefined`

I've also added some styles to improve the editor in mobile.

Fixes #90, and fixes #45