### PR TITLE
Fix PHP notice generated when adding nav menu items

### DIFF
--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -208,7 +208,7 @@ final class WP_Customize_Posts_Preview {
 	 */
 	public function filter_get_post_meta_to_add_dynamic_postmeta_settings( $value, $object_id, $meta_key ) {
 		$post = get_post( $object_id );
-		if ( ! isset( $this->component->registered_post_meta[ $post->post_type ] ) ) {
+		if ( ! $post || ! isset( $this->component->registered_post_meta[ $post->post_type ] ) ) {
 			return $value;
 		}
 


### PR DESCRIPTION
I noticed a PHP notice raised when adding a nav menu item in the Customizer. The notice was generated in `\WP_Customize_Posts_Preview::filter_get_post_meta_to_add_dynamic_postmeta_settings()`. The post ID being passed into this filter is the placeholder (negative) post ID representing a not-yet-inserted `nav_menu_item` post. Nevertheless, in spite of the nav menu item having a negative post ID, it actually gets passed in as an absolute value (`6691070724235418000 ` instead of `-6691070724235418000`). In either case, the ID gets passed into `get_post()` which would fail since it is not a valid post ID. 

The meta lookup that is resulting in this issue is for the `type_label` item.

Call stack:

```
#0  WP_Customize_Posts_Preview->filter_get_post_meta_to_add_dynamic_postmeta_settings()
#1  call_user_func_array() called at [/srv/www/wordpress-develop/src/wp-includes/plugin.php:235]
#2  apply_filters() called at [/srv/www/wordpress-develop/src/wp-includes/meta.php:539]
#3  metadata_exists() called at [/srv/www/wordpress-develop/src/wp-includes/class-wp-post.php:263]
#4  WP_Post->__isset() called at [/srv/www/wordpress-develop/src/wp-includes/customize/class-wp-customize-nav-menu-item-setting.php:547]
#5  WP_Customize_Nav_Menu_Item_Setting->value_as_wp_post_nav_menu_item() called at [/srv/www/wordpress-develop/src/wp-includes/customize/class-wp-customize-nav-menu-item-setting.php:473]
#6  WP_Customize_Nav_Menu_Item_Setting->filter_wp_get_nav_menu_items()
#7  call_user_func_array() called at [/srv/www/wordpress-develop/src/wp-includes/plugin.php:235]
#8  apply_filters() called at [/srv/www/wordpress-develop/src/wp-includes/nav-menu.php:700]
#9  wp_get_nav_menu_items() called at [/srv/www/wordpress-develop/src/wp-includes/nav-menu-template.php:321]
#10 wp_nav_menu() called at [/srv/www/wordpress-develop/src/wp-content/themes/twentysixteen/header.php:56]
#11 require_once(/srv/www/wordpress-develop/src/wp-content/themes/twentysixteen/header.php) called at [/srv/www/wordpress-develop/src/wp-includes/template.php:572]
#12 load_template() called at [/srv/www/wordpress-develop/src/wp-includes/template.php:531]
#13 locate_template() called at [/srv/www/wordpress-develop/src/wp-includes/general-template.php:45]
#14 get_header() called at [/srv/www/wordpress-develop/src/wp-content/themes/twentysixteen/index.php:17]
#15 include(/srv/www/wordpress-develop/src/wp-content/themes/twentysixteen/index.php) called at [/srv/www/wordpress-develop/src/wp-includes/template-loader.php:75]
#16 require_once(/srv/www/wordpress-develop/src/wp-includes/template-loader.php) called at [/srv/www/wordpress-develop/src/wp-blog-header.php:19]
#17 require(/srv/www/wordpress-develop/src/wp-blog-header.php) called at [/srv/www/wordpress-develop/src/index.php:17]
```

The immediate fix for the symptom is to just make sure that the `get_post()` call actually returns non-empty.