### PR TITLE
Export all registered post types to client, but only register panels if show_in_customizer

### DIFF
--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -93,6 +93,9 @@
 			}
 			return;
 		}
+		if ( ! component.data.postTypes[ postType ].show_in_customizer ) {
+			return;
+		}
 		postId = parseInt( idParts[2], 10 );
 		if ( ! postId ) {
 			if ( 'undefined' !== typeof console && console.error ) {

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -87,20 +87,16 @@ final class WP_Customize_Posts {
 		$post_types = array();
 		$post_type_objects = get_post_types( array(), 'objects' );
 		foreach ( $post_type_objects as $post_type_object ) {
-			$is_included = $post_type_object->show_ui;
-			if ( isset( $post_type_object->show_in_customizer ) ) {
-				$is_included = $post_type_object->show_in_customizer;
+			$post_type_object = clone $post_type_object;
+			if ( ! isset( $post_type_object->show_in_customizer ) ) {
+				$post_type_object->show_in_customizer = $post_type_object->show_ui;
 			}
+			$post_type_object->supports = get_all_post_type_supports( $post_type_object->name );
 
-			if ( $is_included ) {
-				$post_type_object = clone $post_type_object;
-				$post_type_object->supports = get_all_post_type_supports( $post_type_object->name );
+			// Remove unnecessary properties.
+			unset( $post_type_object->register_meta_box_cb );
 
-				// Remove unnecessary properties.
-				unset( $post_type_object->register_meta_box_cb );
-
-				$post_types[ $post_type_object->name ] = $post_type_object;
-			}
+			$post_types[ $post_type_object->name ] = $post_type_object;
 		}
 
 		// Skip media as special case.
@@ -228,6 +224,10 @@ final class WP_Customize_Posts {
 		// Note that this does not include nav_menu_item.
 		$this->set_builtin_post_type_descriptions();
 		foreach ( $this->get_post_types() as $post_type_object ) {
+			if ( empty( $post_type_object->show_in_customizer ) ) {
+				continue;
+			}
+
 			$panel_id = sprintf( 'posts[%s]', $post_type_object->name );
 
 			// @todo Should this panel be filterable so that other post types can customize which subclass is used?
@@ -439,6 +439,7 @@ final class WP_Customize_Posts {
 				'menu_icon',
 				'description',
 				'hierarchical',
+				'show_in_customizer',
 			) );
 		}
 

--- a/tests/php/test-class-wp-customize-posts.php
+++ b/tests/php/test-class-wp-customize-posts.php
@@ -234,7 +234,11 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 		$this->do_customize_boot_actions();
 		foreach ( $posts->get_post_types() as $post_type_object ) {
 			$panel_id = sprintf( 'posts[%s]', $post_type_object->name );
-			$this->assertInstanceOf( 'WP_Customize_Posts_Panel', $posts->manager->get_panel( $panel_id ) );
+			if ( empty( $post_type_object->show_in_customizer ) ) {
+				$this->assertNull( $posts->manager->get_panel( $panel_id ) );
+			} else {
+				$this->assertInstanceOf( 'WP_Customize_Posts_Panel', $posts->manager->get_panel( $panel_id ) );
+			}
 		}
 	}
 


### PR DESCRIPTION
Avoids `console.error()` call when suppressing a custom post type from being added as a panel via `show_in_customizer`.

See #128.