### PR TITLE
Add missing text domain to plugin meta

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ Edit posts and postmeta in the Customizer. Stop editing your posts/postmeta blin
 **Tested up to:** 4.6-alpha  
 **Stable tag:** 0.5.0  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
+**Text Domain:** customize-posts  
 
 [![Build Status](https://travis-ci.org/xwp/wp-customize-posts.svg?branch=master)](https://travis-ci.org/xwp/wp-customize-posts) [![Coverage Status](https://coveralls.io/repos/xwp/wp-customize-posts/badge.svg?branch=master)](https://coveralls.io/github/xwp/wp-customize-posts) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.svg)](http://gruntjs.com) [![devDependency Status](https://david-dm.org/xwp/wp-customize-posts/dev-status.svg)](https://david-dm.org/xwp/wp-customize-posts#info=devDependencies) 
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,6 +6,7 @@ Tested up to:      4.6-alpha
 Stable tag:        0.5.0
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain:       customize-posts
 
 Edit posts and postmeta in the Customizer. Stop editing your posts/postmeta blind!
 


### PR DESCRIPTION
There's a notice at https://translate.wordpress.org/projects/wp-plugins/customize-posts

> This plugin is not properly prepared for localization. If you would like to translate this plugin, please contact the author.

I guess it is because we don't have the Text Domain declared.