### PR TITLE
Add support for setting validation in 4.6-alpha

### DIFF
--- a/css/customize-posts.css
+++ b/css/customize-posts.css
@@ -1,7 +1,3 @@
-/* In case Customize Setting Validation is not active */
-div.customize-setting-validation-message.error {
-	display: none;
-}
 
 .customize-posts-panel-notice {
 	color: #555;
@@ -10,12 +6,7 @@ div.customize-setting-validation-message.error {
 	border-top: 1px solid #ddd;
 }
 
-.customize-section-title > div.customize-setting-validation-message {
-	border-top: 1px solid #ddd;
-	margin-top: 0;
-	margin-bottom: 0;
-}
-.customize-setting-validation-message .override-post-conflict {
+.customize-control-notifications-container .override-post-conflict {
 	margin-left: 1ex;
 	float: right;
 }

--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -188,6 +188,21 @@
 		},
 
 		/**
+		 * Prevent notifications for settings from being added to post field control notifications.
+		 *
+		 * @param {string} code                            Notification code.
+		 * @param {wp.customize.Notification} notification Notification object.
+		 * @returns {wp.customize.Notification|null}
+		 */
+		addPostFieldControlNotification: function( code, notification ) {
+			if ( -1 !== code.indexOf( ':' ) ) {
+				return null;
+			} else {
+				return api.Values.prototype.add.call( this, code, notification );
+			}
+		},
+
+		/**
 		 * Add post title control.
 		 *
 		 * @returns {wp.customize.Control}
@@ -217,10 +232,8 @@
 			section.postFieldControls.post_title = control;
 			api.control.add( control.id, control );
 
-			// Remove the setting from the settingValidationMessages since it is not specific to this field.
-			if ( control.settingValidationMessages ) {
-				control.settingValidationMessages.remove( setting.id );
-				control.settingValidationMessages.add( control.id, new api.Value( '' ) );
+			if ( control.notifications ) {
+				control.notifications.add = section.addPostFieldControlNotification;
 			}
 			return control;
 		},
@@ -266,10 +279,8 @@
 			section.postFieldControls.post_name = control;
 			api.control.add( control.id, control );
 
-			// Remove the setting from the settingValidationMessages since it is not specific to this field.
-			if ( control.settingValidationMessages ) {
-				control.settingValidationMessages.remove( setting.id );
-				control.settingValidationMessages.add( control.id, new api.Value( '' ) );
+			if ( control.notifications ) {
+				control.notifications.add = section.addPostFieldControlNotification;
 			}
 			return control;
 		},
@@ -422,10 +433,8 @@
 				control.container.append( control.editorToggleExpandButton );
 			} );
 
-			// Remove the setting from the settingValidationMessages since it is not specific to this field.
-			if ( control.settingValidationMessages ) {
-				control.settingValidationMessages.remove( setting.id );
-				control.settingValidationMessages.add( control.id, new api.Value( '' ) );
+			if ( control.notifications ) {
+				control.notifications.add = section.addPostFieldControlNotification;
 			}
 			return control;
 		},
@@ -460,10 +469,8 @@
 			section.postFieldControls.post_excerpt = control;
 			api.control.add( control.id, control );
 
-			// Remove the setting from the settingValidationMessages since it is not specific to this field.
-			if ( control.settingValidationMessages ) {
-				control.settingValidationMessages.remove( setting.id );
-				control.settingValidationMessages.add( control.id, new api.Value( '' ) );
+			if ( control.notifications ) {
+				control.notifications.add = section.addPostFieldControlNotification;
 			}
 			return control;
 		},
@@ -498,10 +505,8 @@
 			section.postFieldControls.post_discussion_fields = control;
 			api.control.add( control.id, control );
 
-			// Remove the setting from the settingValidationMessages since it is not specific to this field.
-			if ( control.settingValidationMessages ) {
-				control.settingValidationMessages.remove( setting.id );
-				control.settingValidationMessages.add( control.id, new api.Value( '' ) );
+			if ( control.notifications ) {
+				control.notifications.add = section.addPostFieldControlNotification;
 			}
 			return control;
 		},
@@ -537,10 +542,8 @@
 			section.postFieldControls.post_author = control;
 			api.control.add( control.id, control );
 
-			// Remove the setting from the settingValidationMessages since it is not specific to this field.
-			if ( control.settingValidationMessages ) {
-				control.settingValidationMessages.remove( setting.id );
-				control.settingValidationMessages.add( control.id, new api.Value( '' ) );
+			if ( control.notifications ) {
+				control.notifications.add = section.addPostFieldControlNotification;
 			}
 			return control;
 		},
@@ -549,39 +552,65 @@
 		 * Set up setting validation.
 		 */
 		setupSettingValidation: function() {
-			var section = this, setting = api( section.id );
-			if ( ! setting.validationMessage ) {
+			var section = this, setting = api( section.id ), debouncedRenderNotifications;
+			if ( ! setting.notifications ) {
 				return;
 			}
 
-			section.validationMessageElement = $( '<div class="customize-setting-validation-message error" aria-live="assertive"></div>' );
-			section.container.find( '.customize-section-title' ).append( section.validationMessageElement );
-			setting.validationMessage.bind( function( message ) {
-				var template = wp.template( 'customize-setting-validation-message' );
-				section.validationMessageElement.empty().append( $.trim(
-					template( { messages: [ message ] } )
-				) );
-				if ( message ) {
-					section.validationMessageElement.slideDown( 'fast' );
-				} else {
-					section.validationMessageElement.slideUp( 'fast' );
-				}
-				section.container.toggleClass( 'customize-setting-invalid', '' !== message );
+			// Add the notifications API.
+			section.notifications = new api.Values({ defaultConstructor: api.Notification });
+			section.notificationsContainer = $( '<div class="customize-control-notifications-container"></div>' );
+			section.notificationsTemplate = wp.template( 'customize-post-section-notifications' );
+			section.container.find( '.customize-section-title' ).after( section.notificationsContainer );
+			section.getNotificationsContainerElement = function() {
+				return section.notificationsContainer;
+			};
+			section.renderNotifications = api.Control.prototype.renderNotifications;
+
+			// Sync setting notifications into the section notifications
+			setting.notifications.bind( 'add', function( settingNotification ) {
+				var notification = new api.Notification( setting.id + ':' + settingNotification.code, settingNotification );
+				section.notifications.add( notification.code, notification );
+			} );
+			setting.notifications.bind( 'remove', function( settingNotification ) {
+				section.notifications.remove( setting.id + ':' + settingNotification.code );
 			} );
 
+			/*
+			 * Render notifications when the collection is updated.
+			 * Note that this debounced/deferred rendering is needed for two reasons:
+			 * 1) The 'remove' event is triggered just _before_ the notification is actually removed.
+			 * 2) Improve performance when adding/removing multiple notifications at a time.
+			 */
+			debouncedRenderNotifications = _.debounce( function renderNotifications() {
+				section.renderNotifications();
+			} );
+			section.notifications.bind( 'add', function( notification ) {
+				wp.a11y.speak( notification.message, 'assertive' );
+				debouncedRenderNotifications();
+			} );
+			section.notifications.bind( 'remove', debouncedRenderNotifications );
+			section.renderNotifications();
+
 			// Dismiss conflict block when clicking on button.
-			section.validationMessageElement.on( 'click', '.override-post-conflict', function( e ) {
+			section.notificationsContainer.on( 'click', '.override-post-conflict', function( e ) {
 				var ourValue;
 				e.preventDefault();
 				ourValue = _.clone( setting.get() );
 				ourValue.post_modified_gmt = '';
 				setting.set( ourValue );
-				section.resetPostFieldControlSettingValidationMessages();
+
+				_.each( section.postFieldControls, function( control ) {
+					if ( control.notifications ) {
+						control.notifications.remove( 'post_update_conflict' );
+					}
+				} );
+				setting.notifications.remove( 'post_update_conflict' );
 			} );
 
 			// Detect conflict errors.
 			api.bind( 'error', function( response ) {
-				var theirValue, ourValue, overrideButton, wasOverrideButtonAdded = false;
+				var theirValue, ourValue;
 				if ( ! response.update_conflicted_setting_values ) {
 					return;
 				}
@@ -591,39 +620,37 @@
 				}
 				ourValue = setting.get();
 				_.each( theirValue, function( theirFieldValue, fieldId ) {
-					var control, validationMessage;
+					var control, notification;
 					if ( 'post_modified' === fieldId || 'post_modified_gmt' === fieldId || theirFieldValue === ourValue[ fieldId ] ) {
 						return;
 					}
 					control = api.control( setting.id + '[' + fieldId + ']' );
-					if ( control && control.settingValidationMessages && control.settingValidationMessages.has( control.id ) ) {
-						validationMessage = api.Posts.data.l10n.theirChange.replace( '%s', String( theirFieldValue ) );
-						control.settingValidationMessages( control.id ).set( validationMessage );
-
-						if ( ! wasOverrideButtonAdded ) {
-							overrideButton = $( '<button class="button override-post-conflict" type="button"></button>' );
-							overrideButton.text( api.Posts.data.l10n.overrideButtonText );
-							section.validationMessageElement.find( 'li:first' ).prepend( overrideButton );
-							wasOverrideButtonAdded = true;
-						}
+					if ( control && control.notifications ) {
+						notification = new api.Notification( 'post_update_conflict', {
+							message: api.Posts.data.l10n.theirChange.replace( '%s', String( theirFieldValue ) )
+						} );
+						control.notifications.remove( notification.code );
+						control.notifications.add( notification.code, notification );
 					}
 				} );
 			} );
 
 			api.bind( 'save', function() {
-				section.resetPostFieldControlSettingValidationMessages();
+				section.resetPostFieldControlErrorNotifications();
 			} );
 		},
 
 		/**
 		 * Reset all of the validation messages for all of the post fields in the section.
 		 */
-		resetPostFieldControlSettingValidationMessages: function() {
+		resetPostFieldControlErrorNotifications: function() {
 			var section = this;
 			_.each( section.postFieldControls, function( postFieldControl ) {
-				if ( postFieldControl.settingValidationMessages ) {
-					postFieldControl.settingValidationMessages.each( function( validationMessage ) {
-						validationMessage.set( '' );
+				if ( postFieldControl.notifications ) {
+					postFieldControl.notifications.each( function( notification ) {
+						if ( 'error' === notification.type ) {
+							postFieldControl.notifications.remove( notification.code );
+						}
 					} );
 				}
 			} );

--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -1,5 +1,5 @@
 /* global wp, tinyMCE */
-/* eslint consistent-this: [ "error", "section" ], no-magic-numbers: [ "error", { "ignore": [0,1] } ] */
+/* eslint consistent-this: [ "error", "section" ], no-magic-numbers: [ "error", { "ignore": [-1,0,1] } ] */
 
 (function( api, $ ) {
 	'use strict';
@@ -198,7 +198,7 @@
 		 *
 		 * @param {string} code                            Notification code.
 		 * @param {wp.customize.Notification} notification Notification object.
-		 * @returns {wp.customize.Notification|null}
+		 * @returns {wp.customize.Notification|null} Notification if not bypassed.
 		 */
 		addPostFieldControlNotification: function( code, notification ) {
 			if ( -1 !== code.indexOf( ':' ) ) {
@@ -247,7 +247,7 @@
 		/**
 		 * Add post slug control.
 		 *
-		 * @returns {wp.customize.Control}
+		 * @returns {wp.customize.Control} Added control.
 		 */
 		addSlugControl: function() {
 			var section = this, control, setting = api( section.id );

--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -292,55 +292,6 @@
 		},
 
 		/**
-		 * Add post slug control.
-		 *
-		 * @returns {wp.customize.Control}
-		 */
-		addSlugControl: function() {
-			var section = this, control, setting = api( section.id );
-			control = new api.controlConstructor.dynamic( section.id + '[post_name]', {
-				params: {
-					section: section.id,
-					priority: 15,
-					label: api.Posts.data.l10n.fieldSlugLabel,
-					active: true,
-					settings: {
-						'default': setting.id
-					},
-					field_type: 'text',
-					setting_property: 'post_name'
-				}
-			} );
-
-			// Supply a placeholder for the input field to approximate how an empty slug will be derived from the title.
-			control.deferred.embedded.done( function() {
-				var input = control.container.find( 'input' );
-				function setPlaceholder() {
-					var slug = api.Posts.sanitizeTitleWithDashes( setting.get().post_title );
-					input.prop( 'placeholder', slug );
-				}
-				setPlaceholder();
-				setting.bind( setPlaceholder );
-			} );
-
-			// Override preview trying to de-activate control not present in preview context.
-			control.active.validate = function() {
-				return true;
-			};
-
-			// Register.
-			section.postFieldControls.post_name = control;
-			api.control.add( control.id, control );
-
-			// Remove the setting from the settingValidationMessages since it is not specific to this field.
-			if ( control.settingValidationMessages ) {
-				control.settingValidationMessages.remove( setting.id );
-				control.settingValidationMessages.add( control.id, new api.Value( '' ) );
-			}
-			return control;
-		},
-
-		/**
 		 * Add post content control.
 		 *
 		 * @todo It is hacky how the dynamic control is overloaded to connect to the shared TinyMCE editor.

--- a/js/customize-posts-panel.js
+++ b/js/customize-posts-panel.js
@@ -88,15 +88,19 @@
 					button.prop( 'disabled', true );
 
 					postData = {
-						post_type: panel.postType,
 						post_status: 'publish'
 					};
 					if ( postObj.supports.title ) {
 						postData.post_title = api.Posts.data.l10n.noTitle;
 					}
 
-					promise = api.Posts.insertAutoDraftPost( postData );
+					promise = api.Posts.insertAutoDraftPost( panel.postType );
 					promise.done( function( data ) {
+						data.setting.set( _.extend(
+							{},
+							data.setting.get(),
+							postData
+						) );
 
 						// Navigate to the newly-created post if it is public; otherwise, refresh the preview.
 						if ( postObj['public'] && data.url ) {

--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -94,7 +94,7 @@
 	component.insertAutoDraftPost = function( postType ) {
 		var request, deferred = $.Deferred();
 
-		request = wp.ajax.post( 'customize-posts-add-new', {
+		request = wp.ajax.post( 'customize-posts-insert-auto-draft', {
 			'customize-posts-nonce': api.Posts.data.nonce,
 			'wp_customize': 'on',
 			'post_type': postType

--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -88,16 +88,16 @@
 	/**
 	 * Insert a new stubbed `auto-draft` post.
 	 *
-	 * @param {object} params - Parameters to configure the setting.
-	 * @return {Promise} Promise resolved with the added section.
+	 * @param {string} postType Post type to create.
+	 * @return {jQuery.promise} Promise resolved with the added section.
 	 */
-	component.insertAutoDraftPost = function( params ) {
+	component.insertAutoDraftPost = function( postType ) {
 		var request, deferred = $.Deferred();
 
 		request = wp.ajax.post( 'customize-posts-add-new', {
 			'customize-posts-nonce': api.Posts.data.nonce,
 			'wp_customize': 'on',
-			'params': params || {}
+			'post_type': postType
 		} );
 
 		request.done( function( response ) {
@@ -106,7 +106,10 @@
 				deferred.rejectWith( 'no_sections' );
 			} else {
 				deferred.resolve( _.extend(
-					{ section: sections[0] },
+					{
+						section: sections[0],
+						setting: api( sections[0].id )
+					},
 					response
 				) );
 			}

--- a/php/class-wp-customize-dynamic-control.php
+++ b/php/class-wp-customize-dynamic-control.php
@@ -143,7 +143,6 @@ class WP_Customize_Dynamic_Control extends WP_Customize_Control {
 				/>
 			<# } #>
 		<# } #>
-		<div class="customize-setting-validation-message error" aria-live="assertive"></div>
 		<?php
 	}
 }

--- a/php/class-wp-customize-featured-image-controller.php
+++ b/php/class-wp-customize-featured-image-controller.php
@@ -382,6 +382,7 @@ class WP_Customize_Featured_Image_Controller extends WP_Customize_Postmeta_Contr
 	 */
 	public function sanitize_setting( $attachment_id, WP_Customize_Postmeta_Setting $setting ) {
 		unset( $setting );
+		$has_setting_validation = method_exists( 'WP_Customize_Setting', 'validate' );
 
 		$is_valid = (
 			'' === $attachment_id
@@ -397,7 +398,7 @@ class WP_Customize_Featured_Image_Controller extends WP_Customize_Postmeta_Contr
 		 * So $attachment_id is either a valid attachment ID, -1, or false.
 		 */
 		if ( ! $is_valid  ) {
-			return new WP_Error( 'invalid_attachment_id', __( 'The attachment is invalid.', 'customize-posts' ) );
+			return $has_setting_validation ? new WP_Error( 'invalid_attachment_id', __( 'The attachment is invalid.', 'customize-posts' ) ) : null;
 		}
 
 		$attachment_id = $this->sanitize_value( $attachment_id );

--- a/php/class-wp-customize-featured-image-controller.php
+++ b/php/class-wp-customize-featured-image-controller.php
@@ -378,10 +378,9 @@ class WP_Customize_Featured_Image_Controller extends WP_Customize_Postmeta_Contr
 	 *
 	 * @param string                        $attachment_id The value to sanitize.
 	 * @param WP_Customize_Postmeta_Setting $setting       Setting.
-	 * @param bool                          $strict        Whether validation is being done. This is part of the proposed patch in in #34893.
-	 * @return mixed|null Null if an input isn't valid, otherwise the sanitized value.
+	 * @return mixed|WP_Error Sanitized value or `WP_Error` if invalid.
 	 */
-	public function sanitize_setting( $attachment_id, WP_Customize_Postmeta_Setting $setting, $strict = false ) {
+	public function sanitize_setting( $attachment_id, WP_Customize_Postmeta_Setting $setting ) {
 		unset( $setting );
 
 		$is_valid = (
@@ -397,12 +396,8 @@ class WP_Customize_Featured_Image_Controller extends WP_Customize_Postmeta_Contr
 		 * and the meta is registered wit WP_Customize_Featured_Image_Controller::sanitize_value() as the sanitize_callback().
 		 * So $attachment_id is either a valid attachment ID, -1, or false.
 		 */
-		if ( $strict && ! $is_valid  ) {
-			if ( $strict ) {
-				return new WP_Error( 'invalid_attachment_id', __( 'The attachment is invalid.', 'customize-posts' ) );
-			} else {
-				return null;
-			}
+		if ( ! $is_valid  ) {
+			return new WP_Error( 'invalid_attachment_id', __( 'The attachment is invalid.', 'customize-posts' ) );
 		}
 
 		$attachment_id = $this->sanitize_value( $attachment_id );

--- a/php/class-wp-customize-page-template-controller.php
+++ b/php/class-wp-customize-page-template-controller.php
@@ -109,9 +109,10 @@ class WP_Customize_Page_Template_Controller extends WP_Customize_Postmeta_Contro
 	public function sanitize_setting( $page_template, WP_Customize_Postmeta_Setting $setting ) {
 		$post = get_post( $setting->post_id );
 		$page_templates = wp_get_theme()->get_page_templates( $post );
+		$has_setting_validation = method_exists( 'WP_Customize_Setting', 'validate' );
 
 		if ( 'default' !== $page_template && ! isset( $page_templates[ $page_template ] ) ) {
-			return new WP_Error( 'invalid_page_template', __( 'The page template is invalid.', 'customize-posts' ) );
+			return $has_setting_validation ? new WP_Error( 'invalid_page_template', __( 'The page template is invalid.', 'customize-posts' ) ) : null;
 		}
 		return $page_template;
 	}

--- a/php/class-wp-customize-page-template-controller.php
+++ b/php/class-wp-customize-page-template-controller.php
@@ -104,19 +104,14 @@ class WP_Customize_Page_Template_Controller extends WP_Customize_Postmeta_Contro
 	 *
 	 * @param string                        $page_template The value to sanitize.
 	 * @param WP_Customize_Postmeta_Setting $setting       Setting.
-	 * @param bool                          $strict        Whether validation is being done. This is part of the proposed patch in in #34893.
-	 * @return mixed|null Null if an input isn't valid, otherwise the sanitized value.
+	 * @return mixed|WP_Error Sanitized value or WP_Error if invalid valid.
 	 */
-	public function sanitize_setting( $page_template, WP_Customize_Postmeta_Setting $setting, $strict = false ) {
+	public function sanitize_setting( $page_template, WP_Customize_Postmeta_Setting $setting ) {
 		$post = get_post( $setting->post_id );
 		$page_templates = wp_get_theme()->get_page_templates( $post );
 
 		if ( 'default' !== $page_template && ! isset( $page_templates[ $page_template ] ) ) {
-			if ( $strict ) {
-				return new WP_Error( 'invalid_page_template', __( 'The page template is invalid.', 'customize-posts' ) );
-			} else {
-				return null;
-			}
+			return new WP_Error( 'invalid_page_template', __( 'The page template is invalid.', 'customize-posts' ) );
 		}
 		return $page_template;
 	}

--- a/php/class-wp-customize-post-discussion-fields-control.php
+++ b/php/class-wp-customize-post-discussion-fields-control.php
@@ -73,8 +73,6 @@ class WP_Customize_Post_Discussion_Fields_Control extends WP_Customize_Dynamic_C
 			</label>
 			</p>
 		<# } #>
-
-		<div class="customize-setting-validation-message error" aria-live="assertive"></div>
 		<?php
 	}
 }

--- a/php/class-wp-customize-post-setting.php
+++ b/php/class-wp-customize-post-setting.php
@@ -182,6 +182,10 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 			$post_data['post_excerpt'] = preg_replace( '/\r\n/', "\n", $post_data['post_excerpt'] );
 		}
 
+		$post_data = wp_array_slice_assoc(
+			$post_data,
+			array_keys( $this->default )
+		);
 		return $post_data;
 	}
 
@@ -213,11 +217,7 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 	 * @return array
 	 */
 	public function get_post_data( WP_Post $post ) {
-		$post_data = wp_array_slice_assoc(
-			$post->to_array(),
-			array_keys( $this->default )
-		);
-		$post_data = $this->normalize_post_data( $post_data );
+		$post_data = $this->normalize_post_data( $post->to_array() );
 		return $post_data;
 	}
 

--- a/php/class-wp-customize-post-setting.php
+++ b/php/class-wp-customize-post-setting.php
@@ -266,7 +266,7 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 		}
 		$post_data['post_type'] = $this->post_type;
 
-		if ( $update ) {
+		if ( $update && did_action( 'customize_save_validation_before' ) ) {
 			// Check post lock.
 			require_once ABSPATH . 'wp-admin/includes/post.php';
 			$locked_user = wp_check_post_lock( $this->post_id );

--- a/php/class-wp-customize-post-setting.php
+++ b/php/class-wp-customize-post-setting.php
@@ -203,7 +203,10 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 		}
 
 		if ( $this->is_previewed ) {
-			$post_data = array_merge( $post_data, $this->post_value( array() ) );
+			$input_value = $this->post_value( array() );
+			if ( null !== $input_value ) {
+				$post_data = array_merge( $post_data, $input_value );
+			}
 		}
 
 		$post_data = $this->normalize_post_data( $post_data );

--- a/php/class-wp-customize-post-setting.php
+++ b/php/class-wp-customize-post-setting.php
@@ -254,7 +254,7 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 	 */
 	public function sanitize( $post_data ) {
 		global $wpdb;
-		$can_wp_error = method_exists( 'WP_Customize_Setting', 'validate' );
+		$has_setting_validation = method_exists( 'WP_Customize_Setting', 'validate' );
 
 		$post_data = array_merge( $this->default, $post_data );
 
@@ -262,7 +262,7 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 		$post_type_obj = get_post_type_object( $this->post_type );
 
 		if ( ! empty( $post_data['post_type'] ) && $post_data['post_type'] !== $this->post_type ) {
-			return $can_wp_error ? new WP_Error( 'bad_post_type' ) : null;
+			return $has_setting_validation ? new WP_Error( 'bad_post_type' ) : null;
 		}
 		$post_data['post_type'] = $this->post_type;
 
@@ -276,7 +276,7 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 					__( 'Post is currently locked by %s.', 'customize-posts' ),
 					$user ? $user->display_name : __( '(unknown user)', 'customize-posts' )
 				);
-				return $can_wp_error ? new WP_Error( 'post_locked', $error_message ) : null;
+				return $has_setting_validation ? new WP_Error( 'post_locked', $error_message ) : null;
 			}
 
 			// Check post update conflict.
@@ -297,7 +297,7 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 					$user ? $user->display_name : __( '(unknown user)', 'customize-posts' )
 				);
 				$this->posts_component->update_conflicted_settings[ $this->id ] = $this;
-				return $can_wp_error ? new WP_Error( 'post_update_conflict', $error_message ) : null;
+				return $has_setting_validation ? new WP_Error( 'post_update_conflict', $error_message ) : null;
 			}
 		}
 
@@ -314,7 +314,7 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 
 		/** This filter is documented in wp-includes/post.php */
 		if ( apply_filters( 'wp_insert_post_empty_content', $maybe_empty, $post_data ) ) {
-			return $can_wp_error ? new WP_Error( 'empty_content', __( 'Content, title, and excerpt are empty.', 'customize-posts' ) ) : null;
+			return $has_setting_validation ? new WP_Error( 'empty_content', __( 'Content, title, and excerpt are empty.', 'customize-posts' ) ) : null;
 		}
 
 		if ( empty( $post_data['post_status'] ) ) {
@@ -366,7 +366,7 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 		$aa = substr( $post_data['post_date'], 0, 4 );
 		$valid_date = wp_checkdate( $mm, $jj, $aa, $post_data['post_date'] );
 		if ( ! $valid_date ) {
-			return $can_wp_error ? new WP_Error( 'invalid_date', __( 'Whoops, the provided date is invalid.', 'customize-posts' ) ) : null;
+			return $has_setting_validation ? new WP_Error( 'invalid_date', __( 'Whoops, the provided date is invalid.', 'customize-posts' ) ) : null;
 		}
 
 		if ( empty( $post_data['post_date_gmt'] ) || '0000-00-00 00:00:00' === $post_data['post_date_gmt'] ) {

--- a/php/class-wp-customize-postmeta-controller.php
+++ b/php/class-wp-customize-postmeta-controller.php
@@ -56,6 +56,13 @@ abstract class WP_Customize_Postmeta_Controller {
 	public $sanitize_js_callback;
 
 	/**
+	 * Setting validate callback.
+	 *
+	 * @var callable
+	 */
+	public $validate_callback;
+
+	/**
 	 * Setting transport.
 	 *
 	 * @var string
@@ -94,6 +101,9 @@ abstract class WP_Customize_Postmeta_Controller {
 		if ( ! isset( $this->sanitize_js_callback ) ) {
 			$this->sanitize_js_callback = array( $this, 'js_value' );
 		}
+		if ( ! isset( $this->validate_callback ) ) {
+			$this->validate_callback = array( $this, 'validate_setting' );
+		}
 
 		add_action( 'customize_posts_register_meta', array( $this, 'register_meta' ) );
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue_customize_pane_scripts' ) );
@@ -129,6 +139,7 @@ abstract class WP_Customize_Postmeta_Controller {
 			$setting_args = array(
 				'sanitize_callback' => $this->sanitize_callback,
 				'sanitize_js_callback' => $this->sanitize_js_callback,
+				'validate_callback' => $this->validate_callback,
 				'transport' => $this->setting_transport,
 				'theme_supports' => $this->theme_supports,
 				'default' => $this->default,
@@ -191,7 +202,7 @@ abstract class WP_Customize_Postmeta_Controller {
 	}
 
 	/**
-	 * Sanitize (and validate) an input.
+	 * Sanitize an input.
 	 *
 	 * Callback for `customize_sanitize_post_meta_{$meta_key}` filter.
 	 *
@@ -199,12 +210,28 @@ abstract class WP_Customize_Postmeta_Controller {
 	 *
 	 * @param string                        $meta_value The value to sanitize.
 	 * @param WP_Customize_Postmeta_Setting $setting    Setting.
-	 * @param bool                          $strict     Whether validation is being done. This is part of the proposed patch in in #34893.
-	 * @return mixed|null Null if an input isn't valid, otherwise the sanitized value.
+	 * @return mixed|null Sanitized value or `null` if invalid.
 	 */
-	public function sanitize_setting( $meta_value, WP_Customize_Postmeta_Setting $setting, $strict = false ) {
+	public function sanitize_setting( $meta_value, WP_Customize_Postmeta_Setting $setting ) {
 		unset( $setting, $strict );
 		return $meta_value;
+	}
+
+	/**
+	 * Validate an input.
+	 *
+	 * Callback for `customize_validate_post_meta_{$meta_key}` filter.
+	 *
+	 * @see update_metadata()
+	 *
+	 * @param WP_Error                      $validity   Validity.
+	 * @param string                        $meta_value The value to sanitize.
+	 * @param WP_Customize_Postmeta_Setting $setting    Setting.
+	 * @return mixed|null Sanitized value or `null` if invalid.
+	 */
+	public function validate_setting( $validity, $meta_value, WP_Customize_Postmeta_Setting $setting ) {
+		unset( $setting, $meta_value );
+		return $validity;
 	}
 
 	/**

--- a/php/class-wp-customize-postmeta-controller.php
+++ b/php/class-wp-customize-postmeta-controller.php
@@ -213,7 +213,7 @@ abstract class WP_Customize_Postmeta_Controller {
 	 * @return mixed|null Sanitized value or `null` if invalid.
 	 */
 	public function sanitize_setting( $meta_value, WP_Customize_Postmeta_Setting $setting ) {
-		unset( $setting, $strict );
+		unset( $setting );
 		return $meta_value;
 	}
 
@@ -227,7 +227,7 @@ abstract class WP_Customize_Postmeta_Controller {
 	 * @param WP_Error                      $validity   Validity.
 	 * @param string                        $meta_value The value to sanitize.
 	 * @param WP_Customize_Postmeta_Setting $setting    Setting.
-	 * @return mixed|null Sanitized value or `null` if invalid.
+	 * @return WP_Error Validity.
 	 */
 	public function validate_setting( $validity, $meta_value, WP_Customize_Postmeta_Setting $setting ) {
 		unset( $setting, $meta_value );

--- a/php/class-wp-customize-postmeta-setting.php
+++ b/php/class-wp-customize-postmeta-setting.php
@@ -142,7 +142,7 @@ class WP_Customize_Postmeta_Setting extends WP_Customize_Setting {
 	 * @return mixed|WP_Error|null Sanitized post array or WP_Error if invalid (or null if not WP 4.6-alpha).
 	 */
 	public function sanitize( $meta_value ) {
-		$can_wp_error = method_exists( 'WP_Customize_Setting', 'validate' );
+		$has_setting_validation = method_exists( 'WP_Customize_Setting', 'validate' );
 
 		$meta_type = 'post';
 		$object_id = $this->post_id;
@@ -162,13 +162,13 @@ class WP_Customize_Postmeta_Setting extends WP_Customize_Setting {
 			$meta_value = sanitize_meta( $meta_key, $meta_value, $meta_type );
 		}
 		if ( is_wp_error( $meta_value ) ) {
-			return $can_wp_error ? $meta_value : null;
+			return $has_setting_validation ? $meta_value : null;
 		}
 
 		/** This filter is documented in wp-includes/meta.php */
 		$check = apply_filters( "update_{$meta_type}_metadata", null, $object_id, $meta_key, $meta_value, $prev_value );
 		if ( null !== $check ) {
-			return $can_wp_error ? new WP_Error( 'not_allowed', sprintf( __( 'Update to post meta "%s" blocked.', 'customize-posts' ), $meta_key ) ) : null;
+			return $has_setting_validation ? new WP_Error( 'not_allowed', sprintf( __( 'Update to post meta "%s" blocked.', 'customize-posts' ), $meta_key ) ) : null;
 		}
 
 		return $meta_value;

--- a/php/class-wp-customize-postmeta-setting.php
+++ b/php/class-wp-customize-postmeta-setting.php
@@ -139,15 +139,10 @@ class WP_Customize_Postmeta_Setting extends WP_Customize_Setting {
 	 * @access public
 	 *
 	 * @param string $meta_value The value to sanitize.
-	 * @param bool   $strict     Whether validation is being done. This is part of the proposed patch in in #34893.
-	 * @return mixed|null Null if an input isn't valid, otherwise the sanitized value.
+	 * @return mixed|WP_Error|null Sanitized post array or WP_Error if invalid (or null if not WP 4.6-alpha).
 	 */
-	public function sanitize( $meta_value, $strict = false ) {
-
-		// The customize_validate_settings action is part of the Customize Setting Validation plugin.
-		if ( ! $strict && doing_action( 'customize_validate_settings' ) ) {
-			$strict = true;
-		}
+	public function sanitize( $meta_value ) {
+		$can_wp_error = method_exists( 'WP_Customize_Setting', 'validate' );
 
 		$meta_type = 'post';
 		$object_id = $this->post_id;
@@ -159,23 +154,21 @@ class WP_Customize_Postmeta_Setting extends WP_Customize_Setting {
 		 *
 		 * @param mixed                $meta_value  Value of the setting.
 		 * @param WP_Customize_Setting $this        WP_Customize_Setting instance.
-		 * @param bool                 $strict      Whether validation is being done. This is part of the proposed patch in in #34893.
 		 */
-		$meta_value = apply_filters( "customize_sanitize_{$this->id}", $meta_value, $this, $strict );
+		$meta_value = apply_filters( "customize_sanitize_{$this->id}", $meta_value, $this );
 
 		// Apply sanitization if value didn't fail validation.
 		if ( ! is_wp_error( $meta_value ) && ! is_null( $meta_value ) ) {
 			$meta_value = sanitize_meta( $meta_key, $meta_value, $meta_type );
 		}
+		if ( is_wp_error( $meta_value ) ) {
+			return $can_wp_error ? $meta_value : null;
+		}
 
 		/** This filter is documented in wp-includes/meta.php */
 		$check = apply_filters( "update_{$meta_type}_metadata", null, $object_id, $meta_key, $meta_value, $prev_value );
 		if ( null !== $check ) {
-			if ( $strict ) {
-				return new WP_Error( 'not_allowed', sprintf( __( 'Update to post meta "%s" blocked.', 'customize-posts' ), $meta_key ) );
-			} else {
-				return null;
-			}
+			return $can_wp_error ? new WP_Error( 'not_allowed', sprintf( __( 'Update to post meta "%s" blocked.', 'customize-posts' ), $meta_key ) ) : null;
 		}
 
 		return $meta_value;

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -182,6 +182,7 @@ final class WP_Customize_Posts {
 				'transport' => null,
 				'sanitize_callback' => null,
 				'sanitize_js_callback' => null,
+				'validate_callback' => null,
 				'setting_class' => 'WP_Customize_Postmeta_Setting',
 			),
 			$setting_args
@@ -529,7 +530,6 @@ final class WP_Customize_Posts {
 				'fieldAuthorLabel' => __( 'Author', 'customize-posts' ),
 				'noTitle' => __( '(no title)', 'customize-posts' ),
 				'theirChange' => __( 'Their change: %s', 'customize-posts' ),
-				'overrideButtonText' => __( 'Override', 'customize-posts' ),
 				'openEditor' => __( 'Open Editor', 'customize-posts' ),
 				'closeEditor' => __( 'Close Editor', 'customize-posts' ),
 			),
@@ -630,6 +630,19 @@ final class WP_Customize_Posts {
 			<button class="customize-posts-navigation dashicons dashicons-visibility" tabindex="0">
 				<span class="screen-reader-text"><?php esc_html_e( 'Preview', 'customize-posts' ); ?> {{ data.label }}</span>
 			</button>
+		</script>
+
+		<script type="text/html" id="tmpl-customize-post-section-notifications">
+			<ul>
+				<# _.each( data.notifications, function( notification ) { #>
+					<li class="notice notice-{{ notification.type || 'info' }} {{ data.altNotice ? 'notice-alt' : '' }}" data-code="{{ notification.code }}" data-type="{{ notification.type }}">
+						<# if ( /post_update_conflict/.test( notification.code ) ) { #>
+							<button class="button override-post-conflict" type="button"><?php esc_html_e( 'Override', 'customize-posts' ); ?></button>
+						<# } #>
+						{{ notification.message || notification.code }}
+					</li>
+				<# } ); #>
+			</ul>
 		</script>
 		<?php
 	}

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -90,7 +90,7 @@ final class WP_Customize_Posts {
 		add_filter( 'post_link', array( $this, 'post_link_draft' ), 10, 2 );
 		add_filter( 'post_type_link', array( $this, 'post_link_draft' ), 10, 2 );
 		add_filter( 'page_link', array( $this, 'post_link_draft' ), 10, 2 );
-		add_action( 'wp_ajax_customize-posts-add-new', array( $this, 'ajax_add_new_post' ) );
+		add_action( 'wp_ajax_customize-posts-insert-auto-draft', array( $this, 'ajax_insert_auto_draft_post' ) );
 
 		$this->preview = new WP_Customize_Posts_Preview( $this );
 	}
@@ -759,10 +759,10 @@ final class WP_Customize_Posts {
 	/**
 	 * Ajax handler for adding a new post.
 	 *
-	 * @action wp_ajax_customize-posts-add-new
+	 * @action wp_ajax_customize-posts-insert-auto-draft
 	 * @access public
 	 */
-	public function ajax_add_new_post() {
+	public function ajax_insert_auto_draft_post() {
 		if ( ! check_ajax_referer( 'customize-posts', 'customize-posts-nonce', false ) ) {
 			status_header( 400 );
 			wp_send_json_error( 'bad_nonce' );

--- a/tests/php/test-ajax-class-wp-customize-posts.php
+++ b/tests/php/test-ajax-class-wp-customize-posts.php
@@ -76,11 +76,11 @@ class Test_Ajax_WP_Customize_Posts extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * Testing successful ajax_add_new_post
+	 * Testing successful ajax_insert_auto_draft_post
 	 *
-	 * @see WP_Customize_Posts::ajax_add_new_post()
+	 * @see WP_Customize_Posts::ajax_insert_auto_draft_post()
 	 */
-	function test_ajax_add_new_post_success() {
+	function test_ajax_insert_auto_draft_post_success() {
 		add_theme_support( 'post-thumbnails' );
 		$this->posts_component->register_meta();
 
@@ -89,7 +89,7 @@ class Test_Ajax_WP_Customize_Posts extends WP_Ajax_UnitTestCase {
 			'customize-posts-nonce' => wp_create_nonce( 'customize-posts' ),
 			'post_type' => 'post',
 		) );
-		$this->make_ajax_call( 'customize-posts-add-new' );
+		$this->make_ajax_call( 'customize-posts-insert-auto-draft' );
 
 		// Get the results.
 		$response = json_decode( $this->_last_response, true );
@@ -106,11 +106,11 @@ class Test_Ajax_WP_Customize_Posts extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * Testing successful ajax_add_new_post
+	 * Testing successful ajax_insert_auto_draft_post
 	 *
-	 * @see WP_Customize_Posts::ajax_add_new_post()
+	 * @see WP_Customize_Posts::ajax_insert_auto_draft_post()
 	 */
-	function test_ajax_add_new_post_failure() {
+	function test_ajax_insert_auto_draft_post_failure() {
 		$post_data_params = array(
 			'post_type' => 'post',
 			'menu_order' => 1,
@@ -121,7 +121,7 @@ class Test_Ajax_WP_Customize_Posts extends WP_Ajax_UnitTestCase {
 			'customize-posts-nonce' => wp_create_nonce( 'customize-posts' ),
 			'params' => $post_data_params,
 		) );
-		$this->make_ajax_call( 'customize-posts-add-new' );
+		$this->make_ajax_call( 'customize-posts-insert-auto-draft' );
 
 		// Get the results.
 		$response = json_decode( $this->_last_response, true );
@@ -130,12 +130,12 @@ class Test_Ajax_WP_Customize_Posts extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * Testing ajax_add_new_post bad_nonce check
+	 * Testing ajax_insert_auto_draft_post bad_nonce check
 	 *
-	 * @see WP_Customize_Posts::ajax_add_new_post()
+	 * @see WP_Customize_Posts::ajax_insert_auto_draft_post()
 	 */
-	function test_ajax_add_new_post_bad_nonce() {
-		$this->make_ajax_call( 'customize-posts-add-new' );
+	function test_ajax_insert_auto_draft_post_bad_nonce() {
+		$this->make_ajax_call( 'customize-posts-insert-auto-draft' );
 
 		// Get the results.
 		$response = json_decode( $this->_last_response, true );
@@ -148,17 +148,17 @@ class Test_Ajax_WP_Customize_Posts extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * Testing ajax_add_new_post customize_not_allowed check
+	 * Testing ajax_insert_auto_draft_post customize_not_allowed check
 	 *
-	 * @see WP_Customize_Posts::ajax_add_new_post()
+	 * @see WP_Customize_Posts::ajax_insert_auto_draft_post()
 	 */
-	function test_ajax_add_new_post_customize_not_allowed() {
+	function test_ajax_insert_auto_draft_post_customize_not_allowed() {
 		wp_set_current_user( $this->factory->user->create( array( 'role' => 'subscriber' ) ) );
 		$_POST = array(
 			'action' => 'customize-posts',
 			'customize-posts-nonce' => wp_create_nonce( 'customize-posts' ),
 		);
-		$this->make_ajax_call( 'customize-posts-add-new' );
+		$this->make_ajax_call( 'customize-posts-insert-auto-draft' );
 
 		// Get the results.
 		$response = json_decode( $this->_last_response, true );
@@ -171,16 +171,16 @@ class Test_Ajax_WP_Customize_Posts extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * Testing ajax_add_new_post missing_post_type check
+	 * Testing ajax_insert_auto_draft_post missing_post_type check
 	 *
-	 * @see WP_Customize_Posts::ajax_add_new_post()
+	 * @see WP_Customize_Posts::ajax_insert_auto_draft_post()
 	 */
-	function test_ajax_add_new_post_missing_post_type() {
+	function test_ajax_insert_auto_draft_post_missing_post_type() {
 		$_POST = array(
 			'action' => 'customize-posts',
 			'customize-posts-nonce' => wp_create_nonce( 'customize-posts' ),
 		);
-		$this->make_ajax_call( 'customize-posts-add-new' );
+		$this->make_ajax_call( 'customize-posts-insert-auto-draft' );
 
 		// Get the results.
 		$response = json_decode( $this->_last_response, true );
@@ -193,11 +193,11 @@ class Test_Ajax_WP_Customize_Posts extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * Testing ajax_add_new_post insufficient_post_permissions check
+	 * Testing ajax_insert_auto_draft_post insufficient_post_permissions check
 	 *
-	 * @see WP_Customize_Posts::ajax_add_new_post()
+	 * @see WP_Customize_Posts::ajax_insert_auto_draft_post()
 	 */
-	function test_ajax_add_new_post_insufficient_post_permissions() {
+	function test_ajax_insert_auto_draft_post_insufficient_post_permissions() {
 		remove_filter( 'user_has_cap', array( $GLOBALS['customize_posts_plugin'], 'grant_customize_capability' ), 10 );
 		$role = get_role( 'administrator' );
 		$role->add_cap( 'customize' );
@@ -209,7 +209,7 @@ class Test_Ajax_WP_Customize_Posts extends WP_Ajax_UnitTestCase {
 			'customize-posts-nonce' => wp_create_nonce( 'customize-posts' ),
 			'post_type' => 'post',
 		);
-		$this->make_ajax_call( 'customize-posts-add-new' );
+		$this->make_ajax_call( 'customize-posts-insert-auto-draft' );
 
 		// Get the results.
 		$response = json_decode( $this->_last_response, true );

--- a/tests/php/test-ajax-class-wp-customize-posts.php
+++ b/tests/php/test-ajax-class-wp-customize-posts.php
@@ -68,24 +68,64 @@ class Test_Ajax_WP_Customize_Posts extends WP_Ajax_UnitTestCase {
 	}
 
 	/**
-	 * Testing ajax_add_new_post
+	 * Testing successful ajax_add_new_post
 	 *
 	 * @see WP_Customize_Posts::ajax_add_new_post()
 	 */
-	function test_ajax_add_new_post() {
-		$_POST = array(
+	function test_ajax_add_new_post_success() {
+		$post_data_params = array(
+			'post_type' => 'post',
+			'post_title' => '(untitled)',
+			'menu_order' => 1,
+		);
+
+		$_POST = wp_slash( array(
 			'action' => 'customize-posts',
 			'customize-posts-nonce' => wp_create_nonce( 'customize-posts' ),
-			'params' => array(
-				'post_type' => 'post',
-			),
-		);
+			'params' => $post_data_params,
+		) );
 		$this->make_ajax_call( 'customize-posts-add-new' );
 
 		// Get the results.
 		$response = json_decode( $this->_last_response, true );
+
+		$this->assertTrue( $response['success'] );
 		$this->assertArrayHasKey( 'sectionId', $response['data'] );
 		$this->assertArrayHasKey( 'url', $response['data'] );
+		$this->assertArrayHasKey( 'settings', $response['data'] );
+		$this->assertCount( 1, $response['data']['settings'] );
+		$setting_params = current( $response['data']['settings'] );
+
+		unset( $post_data_params['post_type'] );
+		foreach ( $post_data_params as $key => $value ) {
+			$this->assertEquals( $value, $setting_params['value'][ $key ] );
+		}
+		$this->assertArrayNotHasKey( 'ID', $setting_params['value'] );
+		$this->assertArrayNotHasKey( 'filter', $setting_params['value'] );
+	}
+
+	/**
+	 * Testing successful ajax_add_new_post
+	 *
+	 * @see WP_Customize_Posts::ajax_add_new_post()
+	 */
+	function test_ajax_add_new_post_failure() {
+		$post_data_params = array(
+			'post_type' => 'post',
+			'menu_order' => 1,
+		);
+
+		$_POST = wp_slash( array(
+			'action' => 'customize-posts',
+			'customize-posts-nonce' => wp_create_nonce( 'customize-posts' ),
+			'params' => $post_data_params,
+		) );
+		$this->make_ajax_call( 'customize-posts-add-new' );
+
+		// Get the results.
+		$response = json_decode( $this->_last_response, true );
+
+		$this->assertFalse( $response['success'] );
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-featured-image-controller.php
+++ b/tests/php/test-class-wp-customize-featured-image-controller.php
@@ -280,8 +280,13 @@ class Test_WP_Customize_Featured_Image_Controller extends WP_UnitTestCase {
 		$setting_id = WP_Customize_Postmeta_Setting::get_post_meta_setting_id( $post, $controller->meta_key );
 		$setting = new WP_Customize_Postmeta_Setting( $this->wp_customize, $setting_id );
 
-		$this->assertEquals( '', $controller->sanitize_setting( 'bad', $setting, false ) );
-		$this->assertInstanceOf( 'WP_Error', $controller->sanitize_setting( 'bad', $setting, true ) );
+		$can_wp_error = method_exists( 'WP_Customize_Setting', 'validate' );
+		if ( $can_wp_error ) {
+			$error = $controller->sanitize_setting( 'bad', $setting );
+			$this->assertInstanceOf( 'WP_Error', $error );
+		} else {
+			$this->assertEquals( '', $controller->sanitize_setting( 'bad', $setting ) );
+		}
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-featured-image-controller.php
+++ b/tests/php/test-class-wp-customize-featured-image-controller.php
@@ -280,8 +280,8 @@ class Test_WP_Customize_Featured_Image_Controller extends WP_UnitTestCase {
 		$setting_id = WP_Customize_Postmeta_Setting::get_post_meta_setting_id( $post, $controller->meta_key );
 		$setting = new WP_Customize_Postmeta_Setting( $this->wp_customize, $setting_id );
 
-		$can_wp_error = method_exists( 'WP_Customize_Setting', 'validate' );
-		if ( $can_wp_error ) {
+		$has_setting_validation = method_exists( 'WP_Customize_Setting', 'validate' );
+		if ( $has_setting_validation ) {
 			$error = $controller->sanitize_setting( 'bad', $setting );
 			$this->assertInstanceOf( 'WP_Error', $error );
 		} else {

--- a/tests/php/test-class-wp-customize-page-template-controller.php
+++ b/tests/php/test-class-wp-customize-page-template-controller.php
@@ -143,7 +143,7 @@ class Test_WP_Customize_Page_Template_Controller extends WP_UnitTestCase {
 	 */
 	public function test_sanitize_setting() {
 		switch_theme( 'twentytwelve' );
-		$can_wp_error = method_exists( 'WP_Customize_Setting', 'validate' );
+		$has_setting_validation = method_exists( 'WP_Customize_Setting', 'validate' );
 
 		$controller = new WP_Customize_Page_Template_Controller();
 		$post = get_post( $this->factory()->post->create() );
@@ -157,7 +157,7 @@ class Test_WP_Customize_Page_Template_Controller extends WP_UnitTestCase {
 		$this->assertEquals( $value, $controller->sanitize_setting( $value, $setting ) );
 
 		$value = '../page-templates/bad.php';
-		if ( $can_wp_error ) {
+		if ( $has_setting_validation ) {
 			$sanitized = $controller->sanitize_setting( $value, $setting );
 			$this->assertInstanceOf( 'WP_Error', $sanitized );
 			$this->assertEquals( 'invalid_page_template', $sanitized->get_error_code() );

--- a/tests/php/test-class-wp-customize-page-template-controller.php
+++ b/tests/php/test-class-wp-customize-page-template-controller.php
@@ -143,6 +143,7 @@ class Test_WP_Customize_Page_Template_Controller extends WP_UnitTestCase {
 	 */
 	public function test_sanitize_setting() {
 		switch_theme( 'twentytwelve' );
+		$can_wp_error = method_exists( 'WP_Customize_Setting', 'validate' );
 
 		$controller = new WP_Customize_Page_Template_Controller();
 		$post = get_post( $this->factory()->post->create() );
@@ -150,16 +151,18 @@ class Test_WP_Customize_Page_Template_Controller extends WP_UnitTestCase {
 		$setting = new WP_Customize_Postmeta_Setting( $this->wp_customize, $setting_id );
 
 		$value = 'default';
-		$this->assertEquals( $value, $controller->sanitize_setting( $value, $setting, false ) );
+		$this->assertEquals( $value, $controller->sanitize_setting( $value, $setting ) );
 
 		$value = 'page-templates/full-width.php';
-		$this->assertEquals( $value, $controller->sanitize_setting( $value, $setting, false ) );
+		$this->assertEquals( $value, $controller->sanitize_setting( $value, $setting ) );
 
 		$value = '../page-templates/bad.php';
-		$this->assertNull( $controller->sanitize_setting( $value, $setting, false ) );
-
-		$sanitized = $controller->sanitize_setting( $value, $setting, true );
-		$this->assertInstanceOf( 'WP_Error', $sanitized );
-		$this->assertEquals( 'invalid_page_template', $sanitized->get_error_code() );
+		if ( $can_wp_error ) {
+			$sanitized = $controller->sanitize_setting( $value, $setting );
+			$this->assertInstanceOf( 'WP_Error', $sanitized );
+			$this->assertEquals( 'invalid_page_template', $sanitized->get_error_code() );
+		} else {
+			$this->assertNull( $controller->sanitize_setting( $value, $setting ) );
+		}
 	}
 }

--- a/tests/php/test-class-wp-customize-post-setting.php
+++ b/tests/php/test-class-wp-customize-post-setting.php
@@ -299,10 +299,15 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 	 * @see WP_Customize_Post_Setting::sanitize()
 	 */
 	public function test_sanitize_empty_content() {
+		$has_setting_validation = method_exists( 'WP_Customize_Setting', 'validate' );
 		$setting = $this->create_post_setting();
 		$error = $setting->sanitize( array( 'post_title' => '', 'post_content' => '' ), true );
-		$this->assertInstanceOf( 'WP_Error', $error );
-		$this->assertEquals( 'empty_content', $error->get_error_code() );
+		if ( $has_setting_validation ) {
+			$this->assertInstanceOf( 'WP_Error', $error );
+			$this->assertEquals( 'empty_content', $error->get_error_code() );
+		} else {
+			$this->assertNull( $error );
+		}
 		add_filter( 'wp_insert_post_empty_content', '__return_false' );
 		$data = $setting->sanitize( array( 'post_title' => '', 'post_content' => '' ), true );
 		$this->assertInternalType( 'array', $data );
@@ -315,10 +320,10 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 	 */
 	public function test_sanitize_bad_post_type() {
 		$setting = $this->create_post_setting();
-		$can_wp_error = method_exists( 'WP_Customize_Setting', 'validate' );
+		$has_setting_validation = method_exists( 'WP_Customize_Setting', 'validate' );
 
 		$data = $setting->sanitize( array( 'post_type' => 'bad' ) );
-		if ( $can_wp_error ) {
+		if ( $has_setting_validation ) {
 			$this->assertInstanceOf( 'WP_Error', $data );
 			$this->assertEquals( 'bad_post_type', $data->get_error_code() );
 		} else {
@@ -332,6 +337,7 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 	 * @see WP_Customize_Post_Setting::sanitize()
 	 */
 	public function test_sanitize_locked_post() {
+		$has_setting_validation = method_exists( 'WP_Customize_Setting', 'validate' );
 		$other_user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
 		$setting = $this->create_post_setting( array(
 			'post_author' => $other_user_id,
@@ -344,8 +350,12 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 		$this->assertEquals( $other_user_id, wp_check_post_lock( $setting->post_id ) );
 
 		$error = $setting->sanitize( array( 'post_title' => 'Locked?' ), true );
-		$this->assertInstanceOf( 'WP_Error', $error );
-		$this->assertEquals( 'post_locked', $error->get_error_code() );
+		if ( $has_setting_validation ) {
+			$this->assertInstanceOf( 'WP_Error', $error );
+			$this->assertEquals( 'post_locked', $error->get_error_code() );
+		} else {
+			$this->assertNull( $error );
+		}
 	}
 
 	/**
@@ -354,6 +364,7 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 	 * @see WP_Customize_Post_Setting::sanitize()
 	 */
 	public function test_sanitize_post_conflict() {
+		$has_setting_validation = method_exists( 'WP_Customize_Setting', 'validate' );
 		$setting = $this->create_post_setting();
 
 		$diff = -60;
@@ -372,8 +383,12 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 			compact( 'post_modified_gmt', 'post_modified', 'post_title' )
 		);
 		$error = $setting->sanitize( $dirty_value, true );
-		$this->assertInstanceOf( 'WP_Error', $error );
-		$this->assertEquals( 'post_update_conflict', $error->get_error_code() );
+		if ( $has_setting_validation ) {
+			$this->assertInstanceOf( 'WP_Error', $error );
+			$this->assertEquals( 'post_update_conflict', $error->get_error_code() );
+		} else {
+			$this->assertNull( $error );
+		}
 	}
 
 	/**
@@ -442,6 +457,7 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 	 * @see WP_Customize_Post_Setting::sanitize()
 	 */
 	public function test_sanitize_default_post_date() {
+		$has_setting_validation = method_exists( 'WP_Customize_Setting', 'validate' );
 		$setting = $this->create_post_setting( array(
 			'post_status' => 'publish',
 		) );
@@ -463,7 +479,11 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 				'post_date' => '9999-99-99',
 			)
 		), true );
-		$this->assertInstanceOf( 'WP_Error', $sanitized );
+		if ( $has_setting_validation ) {
+			$this->assertInstanceOf( 'WP_Error', $sanitized );
+		} else {
+			$this->assertNull( $sanitized );
+		}
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-post-setting.php
+++ b/tests/php/test-class-wp-customize-post-setting.php
@@ -349,7 +349,9 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 		$this->assertInternalType( 'array', $lock );
 		$this->assertEquals( $other_user_id, wp_check_post_lock( $setting->post_id ) );
 
-		$error = $setting->sanitize( array( 'post_title' => 'Locked?' ), true );
+		$this->assertInternalType( 'array', $setting->sanitize( array( 'post_title' => 'Locked?' ) ) );
+		do_action( 'customize_save_validation_before', $this->wp_customize );
+		$error = $setting->sanitize( array( 'post_title' => 'Locked?' ) );
 		if ( $has_setting_validation ) {
 			$this->assertInstanceOf( 'WP_Error', $error );
 			$this->assertEquals( 'post_locked', $error->get_error_code() );
@@ -375,13 +377,16 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 			$setting->value(),
 			compact( 'post_modified_gmt', 'post_modified' )
 		);
-		$this->assertInternalType( 'array', $setting->sanitize( $dirty_value, true ) );
+		$this->assertInternalType( 'array', $setting->sanitize( $dirty_value ) );
 
 		$post_title = 'Override post title';
 		$dirty_value = array_merge(
 			$setting->value(),
 			compact( 'post_modified_gmt', 'post_modified', 'post_title' )
 		);
+
+		$this->assertInternalType( 'array', $setting->sanitize( $dirty_value ) );
+		do_action( 'customize_save_validation_before', $this->wp_customize );
 		$error = $setting->sanitize( $dirty_value, true );
 		if ( $has_setting_validation ) {
 			$this->assertInstanceOf( 'WP_Error', $error );
@@ -471,7 +476,6 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 		) );
 		$this->assertNotEmpty( $sanitized['post_date_gmt'] );
 		$this->assertNotEmpty( $sanitized['post_date'] );
-
 
 		$sanitized = $setting->sanitize( array_merge(
 			$setting->value(),

--- a/tests/php/test-class-wp-customize-post-setting.php
+++ b/tests/php/test-class-wp-customize-post-setting.php
@@ -315,12 +315,15 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 	 */
 	public function test_sanitize_bad_post_type() {
 		$setting = $this->create_post_setting();
+		$can_wp_error = method_exists( 'WP_Customize_Setting', 'validate' );
 
-		$data = $setting->sanitize( array( 'post_type' => 'bad' ), false );
-		$this->assertArrayNotHasKey( 'post_type', $data );
-		$data = $setting->sanitize( array( 'post_type' => 'bad' ), true );
-		$this->assertInstanceOf( 'WP_Error', $data );
-		$this->assertEquals( 'bad_post_type', $data->get_error_code() );
+		$data = $setting->sanitize( array( 'post_type' => 'bad' ) );
+		if ( $can_wp_error ) {
+			$this->assertInstanceOf( 'WP_Error', $data );
+			$this->assertEquals( 'bad_post_type', $data->get_error_code() );
+		} else {
+			$this->assertNull( $data );
+		}
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-postmeta-setting.php
+++ b/tests/php/test-class-wp-customize-postmeta-setting.php
@@ -210,7 +210,7 @@ class Test_Customize_Postmeta_Setting extends WP_UnitTestCase {
 	/**
 	 * @see WP_Customize_Postmeta_Setting::sanitize()
 	 */
-	function test_sanitize_non_strict() {
+	function test_sanitize() {
 		$post_id = $this->factory()->post->create( array( 'post_type' => 'post') );
 		$meta_key = 'abbreviation';
 		register_meta( 'post', $meta_key, array( $this, 'sanitize_abbreviation' ) );
@@ -230,10 +230,13 @@ class Test_Customize_Postmeta_Setting extends WP_UnitTestCase {
 		$setting_id = WP_Customize_Postmeta_Setting::get_post_meta_setting_id( get_post( $post_id ), $meta_key );
 		$setting = new WP_Customize_Postmeta_Setting( $this->manager, $setting_id );
 		add_filter( 'update_post_metadata', '__return_false' );
-		$this->assertNull( $setting->sanitize( 'nasa' ) );
-		$error = $setting->sanitize( 'nasa', true );
-		$this->assertInstanceOf( 'WP_Error', $error );
-		$this->assertEquals( 'not_allowed', $error->get_error_code() );
+		$error = $setting->sanitize( 'nasa' );
+		if ( ! method_exists( 'WP_Customize_Setting', 'validate' ) ) {
+			$this->assertNull( $error );
+		} else {
+			$this->assertInstanceOf( 'WP_Error', $error );
+			$this->assertEquals( 'not_allowed', $error->get_error_code() );
+		}
 	}
 
 	/**
@@ -262,8 +265,16 @@ class Test_Customize_Postmeta_Setting extends WP_UnitTestCase {
 			'sanitize_callback' => array( $this->plugin->page_template_controller, 'sanitize_setting' )
 		) );
 
+		$can_validate_wp_error = method_exists( 'WP_Customize_Setting', 'validate' );
+
 		$this->assertEquals( 'default', $setting->sanitize( 'default' ) );
-		$this->assertNull( $setting->sanitize( 'bad-template.php' ) );
+		if ( $can_validate_wp_error ) {
+			$error = $setting->sanitize( 'bad-template.php' );
+			$this->assertInstanceOf( 'WP_Error', $error );
+			$this->assertEquals( 'invalid_page_template', $error->get_error_code() );
+		} else {
+			$this->assertNull( $setting->sanitize( 'bad-template.php' ) );
+		}
 		$page_template = 'page-templates/front-page.php';
 		$this->assertEquals( $page_template, $setting->sanitize( $page_template ) );
 	}

--- a/tests/php/test-class-wp-customize-postmeta-setting.php
+++ b/tests/php/test-class-wp-customize-postmeta-setting.php
@@ -265,10 +265,10 @@ class Test_Customize_Postmeta_Setting extends WP_UnitTestCase {
 			'sanitize_callback' => array( $this->plugin->page_template_controller, 'sanitize_setting' )
 		) );
 
-		$can_validate_wp_error = method_exists( 'WP_Customize_Setting', 'validate' );
+		$has_setting_validation = method_exists( 'WP_Customize_Setting', 'validate' );
 
 		$this->assertEquals( 'default', $setting->sanitize( 'default' ) );
-		if ( $can_validate_wp_error ) {
+		if ( $has_setting_validation ) {
 			$error = $setting->sanitize( 'bad-template.php' );
 			$this->assertInstanceOf( 'WP_Error', $error );
 			$this->assertEquals( 'invalid_page_template', $error->get_error_code() );

--- a/tests/php/test-class-wp-customize-posts.php
+++ b/tests/php/test-class-wp-customize-posts.php
@@ -198,6 +198,7 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 			'transport' => 'postMessage',
 			'sanitize_callback' => 'sanitize_key',
 			'sanitize_js_callback' => 'sanitize_key',
+			'validate_callback' => array( $this, 'validate_setting' ),
 			'setting_class' => 'WP_Customize_Postmeta_Setting',
 		);
 		$this->posts->register_post_type_meta( 'post', 'timezone', $args );
@@ -216,6 +217,7 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 		$this->assertEquals( $args['transport'], $setting->transport );
 		$this->assertEquals( $args['sanitize_callback'], $setting->sanitize_callback );
 		$this->assertEquals( $args['sanitize_js_callback'], $setting->sanitize_js_callback );
+		$this->assertEquals( $args['validate_callback'], $setting->validate_callback );
 		$this->assertInstanceOf( $args['setting_class'], $setting );
 	}
 

--- a/tests/php/test-class-wp-customize-posts.php
+++ b/tests/php/test-class-wp-customize-posts.php
@@ -217,7 +217,9 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 		$this->assertEquals( $args['transport'], $setting->transport );
 		$this->assertEquals( $args['sanitize_callback'], $setting->sanitize_callback );
 		$this->assertEquals( $args['sanitize_js_callback'], $setting->sanitize_js_callback );
-		$this->assertEquals( $args['validate_callback'], $setting->validate_callback );
+		if ( method_exists( 'WP_Customize_Setting', 'validate' ) ) {
+			$this->assertEquals( $args['validate_callback'], $setting->validate_callback );
+		}
 		$this->assertInstanceOf( $args['setting_class'], $setting );
 	}
 


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/134745/15600804/2c8114aa-23a1-11e6-8143-acd013b6099f.png)

Validation for post locking and post conflicts is only applied at save.

Post locking:

![image](https://cloud.githubusercontent.com/assets/134745/15599890/6949fc5e-239b-11e6-83b4-35eacb62f0b1.png)

Post conflicts:

![image](https://cloud.githubusercontent.com/assets/134745/15599945/cbb84544-239b-11e6-8770-51328a16e647.png)

Fixes #142.