### PR TITLE
Send values to JS via js_value(); use setting json method if available

### DIFF
--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -729,12 +729,16 @@ final class WP_Customize_Posts_Preview {
 				continue;
 			}
 			if ( $setting instanceof WP_Customize_Post_Setting || $setting instanceof WP_Customize_Postmeta_Setting ) {
-				$results['customize_post_settings'][ $setting->id ] = array(
-					'value' => $setting->value(),
-					'transport' => $setting->transport,
-					'dirty' => $setting->dirty,
-					'type' => $setting->type,
-				);
+				if ( method_exists( $setting, 'json' ) ) { // New in 4.6-alpha.
+					$results['customize_post_settings'][ $setting->id ] = $setting->json();
+				} else {
+					$results['customize_post_settings'][ $setting->id ] = array(
+						'value' => $setting->js_value(),
+						'transport' => $setting->transport,
+						'dirty' => $setting->dirty,
+						'type' => $setting->type,
+					);
+				}
 			}
 		}
 

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -516,7 +516,7 @@ final class WP_Customize_Posts {
 		if ( ! empty( $this->update_conflicted_settings ) ) {
 			$response['update_conflicted_setting_values'] = array();
 			foreach ( $this->update_conflicted_settings as $setting_id => $setting ) {
-				$response['update_conflicted_setting_values'][ $setting_id ] = $setting->value();
+				$response['update_conflicted_setting_values'][ $setting_id ] = $setting->js_value();
 			}
 		}
 		return $response;
@@ -537,7 +537,7 @@ final class WP_Customize_Posts {
 		foreach ( array_keys( $this->manager->unsanitized_post_values() ) as $setting_id ) {
 			$setting = $this->manager->get_setting( $setting_id );
 			if ( $setting instanceof WP_Customize_Post_Setting || $setting instanceof WP_Customize_Postmeta_Setting ) {
-				$response['saved_post_setting_values'][ $setting->id ] = $setting->value();
+				$response['saved_post_setting_values'][ $setting->id ] = $setting->js_value();
 			}
 		}
 		return $response;


### PR DESCRIPTION
This fixes an issue whereby:

1. You change a featured image.
2. You hit Save & Publish.
3. You see the featured image refresh in the preview once saved.

The reason for the secondary refresh of the featured image is because I incorrectly used `WP_Customize_Setting::value()` as opposed to `WP_Customize_Setting::js_value()`. For postmeta containing post IDs for media controls like Featured Image, this is particularly important because all scalar postmeta (e.g. numbers and bools) get saved as strings (since a `meta_value` is a `TEXT` field). We implement a `js_value` to cast the underlying string attachment ID from a string to an integer for JS. Since I didn't do this, when the Customizer saves and it sends back the sanitized saved values to update in the JS models, any integer post IDs get replaced with string post IDs. The result is the secondary partial refresh.

If, on the other hand, a `refresh` is done due to there not being a partial (and so falling back to refesh), the resulting behavior at saving is an _infinite reload_, since the Customizer keeps trying to sync a string value into the preview where there is an integer value already exported, triggering a change on that setting value.

----

To prevent partial refresh from causing an infinite reload this patch should also be applied to core (see [#37032](https://core.trac.wordpress.org/ticket/37032)), as it prevents any setting changes from triggering a partial refresh until `active` has been received (after the initial setting `sync`):

```diff
diff --git src/wp-includes/js/customize-selective-refresh.js src/wp-includes/js/customize-selective-refresh.js
index 7efee3d..9a11b24 100644
--- src/wp-includes/js/customize-selective-refresh.js
+++ src/wp-includes/js/customize-selective-refresh.js
@@ -2,7 +2,7 @@
 
 wp.customize.selectiveRefresh = ( function( $, api ) {
 	'use strict';
-	var self, Partial, Placement;
+	var self, Partial, Placement, active = false;
 
 	self = {
 		ready: $.Deferred(),
@@ -779,6 +779,9 @@ wp.customize.selectiveRefresh = ( function( $, api ) {
 		 */
 		handleSettingChange = function( newValue, oldValue ) {
 			var setting = this;
+			if ( ! active ) {
+				return;
+			}
 			self.partial.each( function( partial ) {
 				if ( partial.isRelatedSetting( setting, newValue, oldValue ) ) {
 					partial.refresh();
@@ -848,6 +851,7 @@ wp.customize.selectiveRefresh = ( function( $, api ) {
 		} );
 
 		api.preview.bind( 'active', function() {
+			active = true;
 
 			// Make all partials ready.
 			self.partial.each( function( partial ) {
```