### PR TITLE
Make sure the customize-draft status is avialble to Snapshots & wp-admin

### DIFF
--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -62,6 +62,7 @@ class Customize_Posts_Plugin {
 
 		add_action( 'wp_default_scripts', array( $this, 'register_scripts' ), 11 );
 		add_action( 'wp_default_styles', array( $this, 'register_styles' ), 11 );
+		add_action( 'init', array( $this, 'register_customize_draft' ) );
 		add_filter( 'user_has_cap', array( $this, 'grant_customize_capability' ), 10, 3 );
 		add_filter( 'customize_loaded_components', array( $this, 'filter_customize_loaded_components' ), 100, 2 );
 		add_action( 'customize_register', array( $this, 'load_support_classes' ) );
@@ -81,6 +82,24 @@ class Customize_Posts_Plugin {
 	function has_required_core_version() {
 		$has_required_wp_version = version_compare( str_replace( array( '-src' ), '', $GLOBALS['wp_version'] ), '4.5-beta2', '>=' );
 		return $has_required_wp_version;
+	}
+
+	/**
+	 * Register the `customize-draft` post status.
+	 *
+	 * @action init
+	 * @access public
+	 */
+	public function register_customize_draft() {
+		register_post_status( 'customize-draft', array(
+			'label'                     => 'customize-draft',
+			'public'                    => false,
+			'internal'                  => true,
+			'protected'                 => true,
+			'exclude_from_search'       => true,
+			'show_in_admin_all_list'    => false,
+			'show_in_admin_status_list' => false,
+		) );
 	}
 
 	/**

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -93,7 +93,6 @@ final class WP_Customize_Posts {
 		add_filter( 'customize_save_response', array( $this, 'filter_customize_save_response_for_conflicts' ), 10, 2 );
 		add_filter( 'customize_save_response', array( $this, 'filter_customize_save_response_to_export_saved_values' ), 10, 2 );
 		add_action( 'customize_controls_print_footer_scripts', array( $this, 'render_templates' ) );
-		add_action( 'init', array( $this, 'register_customize_draft' ) );
 		add_filter( 'customize_snapshot_save', array( $this, 'transition_customize_draft' ) );
 		add_action( 'after_setup_theme', array( $this, 'preview_customize_draft_post_ids' ) );
 		add_action( 'pre_get_posts', array( $this, 'preview_customize_draft' ) );
@@ -721,24 +720,6 @@ final class WP_Customize_Posts {
 			</ul>
 		</script>
 		<?php
-	}
-
-	/**
-	 * Register the `customize-draft` post status.
-	 *
-	 * @action init
-	 * @access public
-	 */
-	public function register_customize_draft() {
-		register_post_status( 'customize-draft', array(
-			'label'                     => 'customize-draft',
-			'public'                    => false,
-			'internal'                  => true,
-			'protected'                 => true,
-			'exclude_from_search'       => true,
-			'show_in_admin_all_list'    => false,
-			'show_in_admin_status_list' => false,
-		) );
 	}
 
 	/**

--- a/tests/php/test-class-customize-posts-plugin.php
+++ b/tests/php/test-class-customize-posts-plugin.php
@@ -93,6 +93,17 @@ class Test_Customize_Posts_Plugin extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test register_customize_draft method.
+	 *
+	 * @see Customize_Posts_Plugin::register_customize_draft()
+	 */
+	public function test_register_customize_draft() {
+		$this->plugin->register_customize_draft();
+		global $wp_post_statuses;
+		$this->assertArrayHasKey( 'customize-draft', $wp_post_statuses );
+	}
+
+	/**
 	 * Test that the user caps are modified.
 	 *
 	 * @see Customize_Posts_Plugin::grant_customize_capability()

--- a/tests/php/test-class-wp-customize-posts.php
+++ b/tests/php/test-class-wp-customize-posts.php
@@ -376,17 +376,6 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test register_customize_draft method.
-	 *
-	 * @see WP_Customize_Posts::register_customize_draft()
-	 */
-	public function test_register_customize_draft() {
-		$this->posts->register_customize_draft();
-		global $wp_post_statuses;
-		$this->assertArrayHasKey( 'customize-draft', $wp_post_statuses );
-	}
-
-	/**
 	 * Test transition_customize_draft method.
 	 *
 	 * @see WP_Customize_Posts::transition_customize_draft()
@@ -433,7 +422,6 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 	 * @see WP_Customize_Posts::preview_customize_draft()
 	 */
 	public function test_preview_customize_draft_post() {
-		$this->posts->register_customize_draft();
 		$post = $this->posts->insert_auto_draft_post( 'post' );
 		$setting_id = WP_Customize_Post_Setting::get_post_setting_id( $post );
 		$data[ $setting_id ] = array(
@@ -462,7 +450,6 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 	 * @see WP_Customize_Posts::preview_customize_draft()
 	 */
 	public function test_preview_customize_draft_page() {
-		$this->posts->register_customize_draft();
 		$post = $this->posts->insert_auto_draft_post( 'page' );
 		$setting_id = WP_Customize_Post_Setting::get_post_setting_id( $post );
 		$data[ $setting_id ] = array(


### PR DESCRIPTION
If you are previewing a snapshot on the front-end and click the edit post link, you'll see that `map_meta_cap()` throws a few notices that are essentially complaining that `get_post_status_object` is not returning an object. This PR moves the `register_customize_draft` method into `Customize_Posts_Plugin` so the `customize-draft` `post_status` will alway be added; instead of only in the Customizer.