### PR TITLE
Delete auto-draft and customize-draft status posts when saving a trash post_status

### DIFF
--- a/php/class-wp-customize-post-setting.php
+++ b/php/class-wp-customize-post-setting.php
@@ -505,6 +505,13 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 		$data['post_type'] = $this->post_type;
 
 		$is_trashed = 'trash' === $data['post_status'];
+		$is_auto_draft = in_array( get_post_status( $this->post_id ), array( 'auto-draft', 'customize-draft' ), true );
+
+		// If trashing an auto-draft, just delete it straight-away and short-circuit.
+		if ( $is_trashed && $is_auto_draft ) {
+			return false !== wp_delete_post( $this->post_id, true );
+		}
+
 		if ( $is_trashed ) {
 			add_filter( 'wp_insert_post_empty_content', '__return_false', 100 );
 

--- a/tests/php/test-class-wp-customize-post-setting.php
+++ b/tests/php/test-class-wp-customize-post-setting.php
@@ -615,6 +615,33 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 		$this->assertEquals( $trash_post_count + 1, did_action( 'trashed_post' ) );
 	}
 
+
+	/**
+	 * Test update() for trashing auto-draft posts (which means delete).
+	 *
+	 * @see WP_Customize_Post_Setting::update()
+	 */
+	function test_save_trashed_auto_draft() {
+		foreach ( array( 'auto-draft', 'customize-draft' ) as $post_status ) {
+			$original_data = compact( 'post_status' );
+			$setting = $this->create_post_setting( $original_data );
+
+			$override_data = array_merge(
+				$setting->value(),
+				array(
+					'post_status' => 'trash',
+				)
+			);
+			$setting->manager->set_post_value( $setting->id, $override_data );
+
+			$trash_post_count = did_action( 'trashed_post' );
+			$setting->save();
+			$post = get_post( $setting->post_id );
+			$this->assertNull( $post );
+			$this->assertEquals( $trash_post_count, did_action( 'trashed_post' ) );
+		}
+	}
+
 	/**
 	 * Trashed post ID.
 	 *


### PR DESCRIPTION
See #172.