### PR TITLE
Use post type's edit_posts capability for sections instead of default

### DIFF
--- a/php/class-wp-customize-post-section.php
+++ b/php/class-wp-customize-post-section.php
@@ -22,11 +22,42 @@ class WP_Customize_Post_Section extends WP_Customize_Section {
 	public $type = self::TYPE;
 
 	/**
-	 * Setting that this section is related to.
+	 * Post ID.
 	 *
-	 * @var WP_Customize_Post_Setting
+	 * @access public
+	 * @var string
 	 */
-	public $post_setting;
+	public $post_id;
+
+	/**
+	 * Post type.
+	 *
+	 * @access public
+	 * @var string
+	 */
+	public $post_type;
+
+	/**
+	 * WP_Customize_Post_Section constructor.
+	 *
+	 * @param WP_Customize_Manager $manager Manager.
+	 * @param string               $id      Section ID.
+	 * @param array                $args    Section args.
+	 */
+	public function __construct( WP_Customize_Manager $manager, $id, array $args = array() ) {
+
+		// Note we don't throw an exception here because sections with 'temp' as the ID are used by WP_Customize_Manager::register_section_type().
+		if ( preg_match( WP_Customize_Post_Setting::SETTING_ID_PATTERN, $id, $matches ) ) {
+			$args['post_id'] = (int) $matches['post_id'];
+			$args['post_type'] = $matches['post_type'];
+			$post_type_obj = get_post_type_object( $args['post_type'] );
+			if ( ! isset( $args['capability'] ) && $post_type_obj ) {
+				$args['capability'] = $post_type_obj->cap->edit_posts;
+			}
+		}
+
+		parent::__construct( $manager, $id, $args );
+	}
 
 	/**
 	 * Export data to JS.

--- a/tests/php/test-class-wp-customize-post-section.php
+++ b/tests/php/test-class-wp-customize-post-section.php
@@ -103,6 +103,19 @@ class Test_WP_Customize_Post_Section extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure that the expected capability is used for the post sections.
+	 *
+	 * @see WP_Customize_Post_Section::__construct()
+	 */
+	public function test_section_capability() {
+		$page_id = $this->factory()->post->create( array( 'post_type' => 'page' ) );
+		$page = get_post( $page_id );
+		$setting_id = WP_Customize_Post_Setting::get_post_setting_id( $page );
+		$section = new WP_Customize_Post_Section( $this->wp_customize, $setting_id );
+		$this->assertEquals( get_post_type_object( 'page' )->cap->edit_posts, $section->capability );
+	}
+
+	/**
 	 * Test export data to JS.
 	 *
 	 * @see WP_Customize_Post_Section::json()


### PR DESCRIPTION
This fixes an issue where sections disappear if an Editor user attempts to access the Customizer and change a post.