### PR TITLE
Defer embedding section contents until expanded

### DIFF
--- a/js/customize-featured-image.js
+++ b/js/customize-featured-image.js
@@ -15,7 +15,8 @@ var CustomizeFeaturedImage = (function( api ) {
 	/**
 	 * Init component.
 	 *
-	 * @param {object} [configData]
+	 * @param {object} [configData] Config data.
+	 * @return {void}
 	 */
 	component.init = function( configData ) {
 		if ( 'undefined' !== typeof configData ) {
@@ -25,28 +26,30 @@ var CustomizeFeaturedImage = (function( api ) {
 	};
 
 	/**
-	 * Extend existing sections and future sections added with the page template control.
+	 * Extend existing sections and future sections added with the featured image control.
+	 *
+	 * @return {void}
 	 */
 	component.extendSections = function() {
-		api.section.each( function( section ) {
-			component.addControl( section );
-		} );
-		api.section.bind( 'add', function( section ) {
-			component.addControl( section );
-		} );
+		function addSectionControls( section ) {
+			if ( section.extended( api.Posts.PostSection ) ) {
+				section.contentsEmbedded.done( function addControl() {
+					component.addControl( section );
+				} );
+			}
+		}
+		api.section.each( addSectionControls );
+		api.section.bind( 'add', addSectionControls );
 	};
 
 	/**
 	 * Add the page template control to the given section.
 	 *
-	 * @param {wp.customize.Section} section
+	 * @param {wp.customize.Section} section Section.
 	 * @returns {wp.customize.Control|null} The control.
 	 */
 	component.addControl = function( section ) {
 		var control, controlId, settingId, postTypeObj, originalInitFrame;
-		if ( ! section.extended( api.Posts.PostSection ) ) {
-			return null;
-		}
 		postTypeObj = api.Posts.data.postTypes[ section.params.post_type ];
 		if ( ! postTypeObj.supports.thumbnail ) {
 			return null;
@@ -103,6 +106,8 @@ var CustomizeFeaturedImage = (function( api ) {
 		 * Initialize the media frame and preselect
 		 *
 		 * @todo The wp.customize.MediaControl should do this in core.
+		 *
+		 * @return {void}
 		 */
 		control.initFrame = function initFrameAndSetInitialSelection() {
 			originalInitFrame.call( this );

--- a/js/customize-page-template.js
+++ b/js/customize-page-template.js
@@ -16,7 +16,8 @@ var CustomizePageTemplate = (function( api ) {
 	/**
 	 * Init component.
 	 *
-	 * @param {object} [configData]
+	 * @param {object} [configData] Config data.
+	 * @return {void}
 	 */
 	component.init = function( configData ) {
 		if ( 'undefined' !== typeof configData ) {
@@ -27,27 +28,29 @@ var CustomizePageTemplate = (function( api ) {
 
 	/**
 	 * Extend existing sections and future sections added with the page template control.
+	 *
+	 * @return {void}
 	 */
 	component.extendSections = function() {
-		api.section.each( function( section ) {
-			component.addControl( section );
-		} );
-		api.section.bind( 'add', function( section ) {
-			component.addControl( section );
-		} );
+		function addSectionControls( section ) {
+			if ( section.extended( api.Posts.PostSection ) ) {
+				section.contentsEmbedded.done( function addControl() {
+					component.addControl( section );
+				} );
+			}
+		}
+		api.section.each( addSectionControls );
+		api.section.bind( 'add', addSectionControls );
 	};
 
 	/**
 	 * Add the page template control to the given section.
 	 *
-	 * @param {wp.customize.Section} section
+	 * @param {wp.customize.Section} section Section.
 	 * @returns {wp.customize.Control|null} The control.
 	 */
 	component.addControl = function( section ) {
 		var supports, control, controlId, settingId, isActiveCallback;
-		if ( ! section.extended( api.Posts.PostSection ) ) {
-			return null;
-		}
 		supports = api.Posts.data.postTypes[ section.params.post_type ].supports;
 		if ( ! supports['page-attributes'] ) {
 			return null;

--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -306,8 +306,6 @@
 
 		/**
 		 * Focus on the section requested from the preview.
-		 *
-		 * @todo This can be merged into Core to correspond with focus-control-for-setting.
 		 */
 		api.previewer.bind( 'focus-section', function( sectionId ) {
 			var section = api.section( sectionId );
@@ -319,14 +317,54 @@
 		/**
 		 * Focus on the control requested from the preview.
 		 *
-		 * @todo This can be merged into Core to correspond with focus-control-for-setting.
+		 * If the control doesn't exist yet, try to determine the section it would
+		 * be part of by parsing its ID, and then if that section exists, expand it.
+		 * Once expanded, try finding the control again, since controls for post
+		 * sections may get embedded only once section.contentsEmbedded is resolved.
+		 *
+		 * @param {string} controlId Control ID.
+		 * @return {void}
 		 */
-		api.previewer.bind( 'focus-control', function( controlId ) {
-			var control = api.control( controlId );
-			if ( control ) {
-				control.focus();
+		function focusControl( controlId ) {
+			var control, section, postSectionId, matches;
+
+			/**
+			 * Attempt focus on the control.
+			 *
+			 * @returns {boolean} Whether the control exists.
+			 */
+			function tryFocus() {
+				control = api.control( controlId );
+				if ( control ) {
+					control.focus();
+					return true;
+				}
+				return false;
 			}
-		} );
+			if ( tryFocus() ) {
+				return;
+			}
+
+			matches = controlId.match( /^post(?:meta)?\[(.+?)]\[(\d+)]/ );
+			if ( ! matches ) {
+				return;
+			}
+			postSectionId = 'post[' + matches[1] + '][' + matches[2] + ']';
+			section = api.section( postSectionId );
+			if ( ! section || ! section.extended( component.PostSection ) ) {
+				return;
+			}
+			section.expand();
+			section.contentsEmbedded.done( function() {
+				var ms = 500;
+
+				// @todo It is not clear why a delay is needed for focus to work. It could be due to focus failing during animation.
+				_.delay( tryFocus, ms );
+			} );
+		}
+
+		component.focusControl = focusControl;
+		api.previewer.bind( 'focus-control', component.focusControl );
 	} );
 
 })( wp.customize, jQuery );


### PR DESCRIPTION
This implements a key performance improvement. When there are a lot of posts loaded in to the Customizer, and each one has a featured image, in `develop` right now you will see an Ajax request made to fetch the attachment data for each image in the console. This is very wasteful and hurts the server. By waiting to embed the controls until the section is expanded, we can ensure that the controls are only embedded once they are actually needed. This will greatly reduce the hit on the DOM at page load, and also reduce the Ajax requests made for the `MediaControl` instances

Remaining todos:

- [x] Make sure that a section gets expanded when doing shift-click on a partial in the preview.