### PR TITLE
Add support for setting-property control notifications and focusing

### DIFF
--- a/php/class-wp-customize-post-setting.php
+++ b/php/class-wp-customize-post-setting.php
@@ -319,7 +319,7 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 
 		/** This filter is documented in wp-includes/post.php */
 		if ( 'trash' !== $post_data['post_status'] && apply_filters( 'wp_insert_post_empty_content', $maybe_empty, $post_data ) ) {
-			return $has_setting_validation ? new WP_Error( 'empty_content', __( 'Content, title, and excerpt are empty.', 'customize-posts' ) ) : null;
+			return $has_setting_validation ? new WP_Error( 'empty_content', __( 'Content, title, and excerpt are empty.', 'customize-posts' ), array( 'setting_property' => 'post_content' ) ) : null;
 		}
 
 		if ( empty( $post_data['post_status'] ) ) {
@@ -371,7 +371,7 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 		$aa = substr( $post_data['post_date'], 0, 4 );
 		$valid_date = wp_checkdate( $mm, $jj, $aa, $post_data['post_date'] );
 		if ( ! $valid_date ) {
-			return $has_setting_validation ? new WP_Error( 'invalid_date', __( 'Whoops, the provided date is invalid.', 'customize-posts' ) ) : null;
+			return $has_setting_validation ? new WP_Error( 'invalid_date', __( 'Whoops, the provided date is invalid.', 'customize-posts' ), array( 'setting_property' => 'post_date' ) ) : null;
 		}
 
 		if ( empty( $post_data['post_date_gmt'] ) || '0000-00-00 00:00:00' === $post_data['post_date_gmt'] ) {


### PR DESCRIPTION
When a `post` setting is marked as invalid and the returned `WP_Error` includes a `setting_property` field, ensure that the corresponding control for this notification gets the notification displayed and gets focus when attempting to submit.

Depends on https://core.trac.wordpress.org/ticket/36944