### PR TITLE
Prevent customized-posts messages sent via selective-refresh from effecting post-navigation state

### DIFF
--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -192,7 +192,9 @@
 
 			// Hide the link when the post is currently in the preview.
 			api.previewer.bind( 'customized-posts', function( data ) {
-				sectionNavigationButton.toggle( section.params.post_id !== data.queriedPostId );
+				if ( ! _.isUndefined( data.queriedPostId ) ) {
+					sectionNavigationButton.toggle( section.params.post_id !== data.queriedPostId );
+				}
 			} );
 
 			sectionNavigationButton.on( 'click', function( event ) {


### PR DESCRIPTION
I noticed an issue whereby I'd navigate to a post in the preview and expand its section. The “preview” 👀 link would properly disappear. However, as soon as I changed the post title the preview link would re-appear unexpectedly. I found that it was because of the selective refresh also sending `customized-posts` messages, but with only a subset of the data when a full refresh is done. So the solution is to just check if `data.queriedPostId` is undefined.