### PR TITLE
Improve meta query support

### DIFF
--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -367,6 +367,23 @@ final class WP_Customize_Posts_Preview {
 				}
 			}
 		}
+		/**
+		 * Filter customize preview posts.
+		 *
+		 * @param array $post_ids Post ids being filtered.
+		 * @param array array {
+		 *     Args.
+		 *
+		 *     @type \WP_Query $query   WP_Query obj.
+		 *     @type array     $settings Field Values in snapshot.
+		 *     @type bool      $publish IN query or NOT IN query.
+		 * }
+		 */
+		$post_ids = apply_filters( 'customize_previewed_posts', $post_ids, array(
+			'query' => $query,
+			'settings' => $settings,
+			'publish' => $published,
+		) );
 
 		return $post_ids;
 	}

--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -379,7 +379,7 @@ final class WP_Customize_Posts_Preview {
 		 *     @type bool      $publish IN query or NOT IN query.
 		 * }
 		 */
-		$post_ids = apply_filters( 'customize_previewed_posts', $post_ids, array(
+		$post_ids = apply_filters( 'customize_previewed_posts_for_query', $post_ids, array(
 			'query' => $query,
 			'settings' => $settings,
 			'publish' => $published,

--- a/tests/php/test-class-wp-customize-posts-preview.php
+++ b/tests/php/test-class-wp-customize-posts-preview.php
@@ -330,10 +330,13 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 		$this->posts_component->register_post_type_meta( $post_type, $meta_key );
 
 		$post_data = array();
-		foreach ( array( 'foo', 'bar', 'baz' ) as $i => $name ) {
-			$post_id = $this->factory()->post->create( array( 'post_title' => $name ) );
-			$post = get_post( $post_id );
+		foreach ( array( 'foo', 'bar', 'baz', 'qux' ) as $i => $name ) {
+			$post_id             = $this->factory()->post->create( array( 'post_title' => $name ) );
+			$post                = get_post( $post_id );
 			$postmeta_setting_id = WP_Customize_Postmeta_Setting::get_post_meta_setting_id( $post, $meta_key );
+			if ( 'qux' === $name ) {
+				$i = 2;
+			}
 			$this->wp_customize->set_post_value( $postmeta_setting_id, (string) $i );
 			list( $postmeta_setting ) = $this->wp_customize->add_dynamic_settings( array( $postmeta_setting_id ) );
 			$this->assertEquals( $postmeta_setting_id, $postmeta_setting->id );
@@ -342,6 +345,9 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 				'postmeta_setting' => $postmeta_setting,
 				'index' => (string) $i,
 			);
+			if ( 'qux' === $name ) {
+				add_post_meta( $post_id, $meta_key, '0', true );
+			}
 			$postmeta_setting->preview();
 			$this->assertEquals( $post_data[ $name ][ $meta_key ], get_post_meta( $post_id, $meta_key, true ) );
 		}
@@ -365,7 +371,7 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 			'meta_value' => '1',
 			'meta_compare' => '>='
 		) );
-		$this->assertCount( 2, $query_post_with_index_gte_1->posts );
+		$this->assertCount( 3, $query_post_with_index_gte_1->posts );
 
 		$query_post_with_compound_meta_query = new WP_Query( array(
 			'post_type' => $post_type,
@@ -384,6 +390,33 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 			),
 		) );
 		$this->assertCount( 1, $query_post_with_compound_meta_query->posts );
+
+		$query_post_with_in_query = new WP_Query( array(
+			'post_type' => $post_type,
+			'meta_query' => array(
+				'relation' => 'AND',
+				array(
+					'key' => $meta_key,
+					'value' => array( '1', '2' ),
+					'compare' => 'IN',
+				),
+			),
+		) );
+
+		$this->assertCount( 3, $query_post_with_in_query->posts );
+
+		$query_post_where_actual_meta_and_snapshot_with_zero = new WP_Query( array(
+			'post_type' => $post_type,
+			'meta_query' => array(
+				'relation' => 'AND',
+				array(
+					'key' => $meta_key,
+					'value' => '0',
+				),
+			),
+		) );
+
+		$this->assertCount( 1, $query_post_where_actual_meta_and_snapshot_with_zero->posts );
 	}
 
 	/**


### PR DESCRIPTION
Add `IN` Meta query compare support. 

Using `$publish` flag to filter out posts which do not match meta query.

Add filter `customize_previewed_posts_for_query` for filtering previewed posts.