### PR TITLE
Include Select2 As a Dependency for Script

### DIFF
--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -199,7 +199,7 @@ class Customize_Posts_Plugin {
 
 		$handle = 'customize-posts-panel';
 		$src = plugins_url( 'js/customize-posts-panel' . $suffix, dirname( __FILE__ ) );
-		$deps = array( 'customize-controls' );
+		$deps = array( 'select2', 'customize-controls' );
 		$in_footer = 1;
 		$wp_scripts->add( $handle, $src, $deps, $this->version, $in_footer );
 


### PR DESCRIPTION
**Adds 'select2' to the dependency array for customize-posts-panel script.**

On a fresh WP install, the customizer was not fully loading due to a JS error.

![screen shot 2016-07-22 at 4 54 20 pm](https://cloud.githubusercontent.com/assets/2053940/17072897/67197870-5031-11e6-8dc1-aeaafa50d1af.png)

Upon investigation, it was found that it was due to Select2 not being loaded into the page.