### PR TITLE
Fix edit_post_link()

### DIFF
--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -445,13 +445,16 @@
 		} );
 
 		/**
-		 * Focus on the section requested from the preview.
+		 * Ensure a post is added to the Customizer and focus on its section when an edit post link is clicked in preview.
 		 */
-		api.previewer.bind( 'focus-section', function( sectionId ) {
-			var section = api.section( sectionId );
-			if ( section ) {
-				section.focus();
-			}
+		api.previewer.bind( 'edit-post', function( postId ) {
+			var ensuredPromise = api.Posts.ensurePosts( [ postId ] );
+			ensuredPromise.done( function( postsData ) {
+				var postData = postsData[ postId ];
+				if ( postData ) {
+					postData.section.focus();
+				}
+			} );
 		} );
 
 		/**

--- a/js/customize-preview-posts.js
+++ b/js/customize-preview-posts.js
@@ -197,11 +197,11 @@
 			 * Focus on the post section in the Customizer pane when clicking an edit-post-link.
 			 */
 			$( document.body ).on( 'click', '.post-edit-link', function( e ) {
-				var link = $( this ), settingId;
-				settingId = link.data( 'customize-post-setting-id' );
+				var link = $( this ), postId;
+				postId = link.data( 'customize-post-id' );
 				e.preventDefault();
-				if ( settingId ) {
-					api.preview.send( 'focus-section', settingId );
+				if ( postId ) {
+					api.preview.send( 'edit-post', postId );
 				}
 			} );
 		} );

--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -620,10 +620,6 @@ final class WP_Customize_Posts_Preview {
 		if ( ! $this->component->current_user_can_edit_post( $edit_post ) ) {
 			return null;
 		}
-		$setting_id = WP_Customize_Post_Setting::get_post_setting_id( $edit_post );
-		if ( ! $this->component->manager->get_setting( $setting_id ) ) {
-			return null;
-		}
 		return $url;
 	}
 

--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -631,9 +631,7 @@ final class WP_Customize_Posts_Preview {
 	 * @return string Edit link.
 	 */
 	function filter_edit_post_link( $link, $post_id ) {
-		$edit_post = get_post( $post_id );
-		$setting_id = WP_Customize_Post_Setting::get_post_setting_id( $edit_post );
-		$data_attributes = sprintf( ' data-customize-post-setting-id="%s"', $setting_id );
+		$data_attributes = sprintf( ' data-customize-post-id="%d"', $post_id );
 		$link = preg_replace( '/(?<=<a\s)/', $data_attributes, $link );
 		return $link;
 	}

--- a/tests/php/test-class-wp-customize-posts-preview.php
+++ b/tests/php/test-class-wp-customize-posts-preview.php
@@ -693,7 +693,7 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 	public function test_filter_edit_post_link() {
 		$preview = new WP_Customize_Posts_Preview( $this->posts_component );
 		$link = '<a class="edit-me" href="' . esc_url( home_url( '?edit-me' ) ) . '">Edit</a>';
-		$contained = sprintf( ' data-customize-post-setting-id="%s"', WP_Customize_Post_Setting::get_post_setting_id( get_post( $this->post_id ) ) );
+		$contained = sprintf( ' data-customize-post-id="%d"', $this->post_id );
 		$this->assertContains( $contained, $preview->filter_edit_post_link( $link, $this->post_id ) );
 	}
 

--- a/tests/php/test-class-wp-customize-posts-preview.php
+++ b/tests/php/test-class-wp-customize-posts-preview.php
@@ -682,10 +682,6 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 		$this->assertNull( $preview->filter_get_edit_post_link( $edit_post_link, $this->post_id ) );
 
 		wp_set_current_user( $this->user_id );
-		$this->assertNull( $preview->filter_get_edit_post_link( $edit_post_link, $this->post_id ) );
-
-		$setting_id = WP_Customize_Post_Setting::get_post_setting_id( get_post( $this->post_id ) );
-		$preview->component->manager->add_setting( new WP_Customize_Post_Setting( $preview->component->manager, $setting_id ) );
 		$this->assertEquals( $edit_post_link, $preview->filter_get_edit_post_link( $edit_post_link, $this->post_id ) );
 	}
 


### PR DESCRIPTION
Fixes a regression introduced in #196. The reason for the regression is that post settings now are added dynamically with JS instead of statically with PHP every time the preview loads. So now we can change the `focus-section` message to an `edit-post` message and re-use the new `ensurePosts` function to ensure that the section is present and focus on it.