### PR TITLE
Retain previous search term as initial value when starting next search

### DIFF
--- a/js/customize-posts-panel.js
+++ b/js/customize-posts-panel.js
@@ -78,6 +78,9 @@
 				},
 				multiple: false,
 				placeholder: api.Posts.data.l10n.jumpToPostPlaceholder.replace( '%s', postTypeObj.labels.singular_name ),
+				nextSearchTerm: function retainSearchTerm( selectedObject, currentSearchTerm ) {
+					return currentSearchTerm;
+				},
 				width: '80%' // @todo Flex box?
 			});
 


### PR DESCRIPTION
If you have a lot of posts with a similar title, and you want to open several of them, it is currently annoying to have to re-type "Lorem ipsum dolor sit amet" after each selection. Instead, after you have selected a post, the previous search term you entered should be pre-filled the next time you open the Select2 instead of the search box being blank.

The code in this PR is not working presently because `nextSearchTerm` is not working anymore in Select2v4: https://github.com/select2/select2/issues/3902

This should also be implemented for https://github.com/xwp/wp-customize-object-selector