### PR TITLE
Improve UX for trashing posts

### DIFF
--- a/css/customize-posts.css
+++ b/css/customize-posts.css
@@ -224,11 +224,15 @@ body.customize-posts-content-editor-pane-resize #customize-preview:before {
 	text-decoration: line-through;
 }
 
-.customize-control-post_status .trash {
-	color: #a00;
+.customize-control-post_status .trash,
+.customize-control-post_status .untrash {
 	float: right;
 	display: inline-block;
 	margin-top: 5px;
+}
+
+.customize-control-post_status .trash {
+	color: #a00;
 }
 .customize-control-post_status .trash:hover {
 	color: #f00;

--- a/css/customize-posts.css
+++ b/css/customize-posts.css
@@ -220,6 +220,9 @@ body.customize-posts-content-editor-pane-resize #customize-preview:before {
 	width: auto;
 	vertical-align: middle;
 }
+.select2-results__option .trashed-title {
+	text-decoration: line-through;
+}
 
 .customize-control-post_status .trash {
 	color: #a00;

--- a/css/customize-posts.css
+++ b/css/customize-posts.css
@@ -221,6 +221,16 @@ body.customize-posts-content-editor-pane-resize #customize-preview:before {
 	vertical-align: middle;
 }
 
+.customize-control-post_status .trash {
+	color: #a00;
+	float: right;
+	display: inline-block;
+	margin-top: 5px;
+}
+.customize-control-post_status .trash:hover {
+	color: #f00;
+}
+
 .customize-control-post_date .customize-control-description {
 	font-style: normal;
 	display: block;

--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -464,12 +464,6 @@
 			section.postFieldControls.post_status = control;
 			api.control.add( control.id, control );
 
-			// Initialize the trashed UI.
-			// @todo Is this redundant with logic in post_status control's constructor?
-			api.panel( section.panel.get() ).expanded.bind( function() {
-				control.toggleTrash();
-			} );
-
 			if ( control.notifications ) {
 				control.notifications.add = section.addPostFieldControlNotification;
 				control.notifications.setting_property = control.params.setting_property;

--- a/js/customize-post-status-control.js
+++ b/js/customize-post-status-control.js
@@ -36,6 +36,7 @@
 				control.optionFutureElement = control.selectElement.find( 'option[value=future]' );
 				control.optionPublishElement = control.selectElement.find( 'option[value=publish]' );
 				control.trashLink = control.container.find( '.trash' );
+				control.untrashLink = control.container.find( '.untrash' );
 
 				// Defer updating until control explicitly added, because it will short-circuit if not registered yet.
 				api.control( control.id, function() {
@@ -56,6 +57,7 @@
 				}, embeddedDelay );
 
 				// Update the status UI when the setting changes its state.
+				control.originalPostStatus = control.setting().post_status;
 				control.setting.bind( function( newPostData, oldPostData ) {
 					if ( newPostData.post_status !== oldPostData.post_status && 'trash' === newPostData.post_status || 'trash' === oldPostData.post_status ) {
 						control.toggleTrash();
@@ -87,6 +89,14 @@
 					 * change to trash (so they can undo it later).
 					 */
 					_.delay( collapseSection, trashCollapseDelay );
+				} );
+
+				// Restore the original post status when clicking the untrash link.
+				control.untrashLink.on( 'click', function( e ) {
+					var postData = _.clone( control.setting.get() );
+					e.preventDefault();
+					postData.post_status = control.originalPostStatus;
+					control.setting.set( postData );
 				} );
 			} );
 		},
@@ -161,6 +171,9 @@
 
 			if ( control.trashLink ) {
 				control.trashLink.toggle( ! trashed );
+			}
+			if ( control.originalPostStatus ) {
+				control.untrashLink.toggle( Boolean( trashed && control.originalPostStatus ) );
 			}
 
 			section = api.section( control.section.get() );

--- a/js/customize-post-status-control.js
+++ b/js/customize-post-status-control.js
@@ -16,14 +16,13 @@
 			opt = {};
 			opt.params = _.extend(
 				{
+					type: 'post_status', // Used for template.
 					label: api.Posts.data.l10n.fieldStatusLabel,
-					type: 'dynamic', // To re-use the dynamic template.
 					active: true,
 					setting_property: 'post_status',
 					field_type: 'select',
-					choices: api.Posts.data.postStatusChoices,
+					choices: api.Posts.data.postStatusChoices, // @todo Allow post status choices to be specific to post types.
 					updateChoicesInterval: 1000
-
 				},
 				options.params || {}
 			);
@@ -31,11 +30,12 @@
 			api.controlConstructor.dynamic.prototype.initialize.call( control, id, opt );
 
 			control.deferred.embedded.done( function() {
-				var embeddedDelay = 50;
+				var embeddedDelay = 50, collapseSection, trashCollapseDelay = 500;
 
 				control.selectElement = control.container.find( 'select' );
 				control.optionFutureElement = control.selectElement.find( 'option[value=future]' );
 				control.optionPublishElement = control.selectElement.find( 'option[value=publish]' );
+				control.trashLink = control.container.find( '.trash' );
 
 				// Defer updating until control explicitly added, because it will short-circuit if not registered yet.
 				api.control( control.id, function() {
@@ -60,6 +60,33 @@
 					if ( newPostData.post_status !== oldPostData.post_status && 'trash' === newPostData.post_status || 'trash' === oldPostData.post_status ) {
 						control.toggleTrash();
 					}
+				} );
+
+				/**
+				 * Collapse section.
+				 *
+				 * @return {void}
+				 */
+				collapseSection = function() {
+					var section = api.section( control.section() );
+					if ( section ) {
+						section.collapse();
+					}
+				};
+
+				// Trash the post when clicking the delete link.
+				control.trashLink.on( 'click', function( e ) {
+					var postData = _.clone( control.setting.get() );
+					e.preventDefault();
+					postData.post_status = 'trash';
+					control.setting.set( postData );
+
+					/*
+					 * Collapse the section momentarily after trashing the post
+					 * so that the user can visually see the status dropdown
+					 * change to trash (so they can undo it later).
+					 */
+					_.delay( collapseSection, trashCollapseDelay );
 				} );
 			} );
 		},
@@ -130,20 +157,24 @@
 		 */
 		toggleTrash: function() {
 			var control = this, section, sectionContainer, sectionTitle, trashed;
-			section = api.section( control.section.get() );
-			if ( ! section ) {
-				return;
-			}
 			trashed = 'trash' === control.setting.get().post_status;
-			sectionContainer = section.container.closest( '.accordion-section' );
-			sectionTitle = sectionContainer.find( '.accordion-section-title:first' );
-			sectionContainer.toggleClass( 'is-trashed', trashed );
-			if ( true === trashed ) {
-				if ( 0 === sectionTitle.find( '.customize-posts-trashed' ).length ) {
-					sectionTitle.append( wp.template( 'customize-posts-trashed' )() );
+
+			if ( control.trashLink ) {
+				control.trashLink.toggle( ! trashed );
+			}
+
+			section = api.section( control.section.get() );
+			if ( section ) {
+				sectionContainer = section.container.closest( '.accordion-section' );
+				sectionTitle = sectionContainer.find( '.accordion-section-title:first' );
+				sectionContainer.toggleClass( 'is-trashed', trashed );
+				if ( true === trashed ) {
+					if ( 0 === sectionTitle.find( '.customize-posts-trashed' ).length ) {
+						sectionTitle.append( wp.template( 'customize-posts-trashed' )() );
+					}
+				} else {
+					sectionContainer.find( '.customize-posts-trashed' ).remove();
 				}
-			} else {
-				sectionContainer.find( '.customize-posts-trashed' ).remove();
 			}
 		}
 	});

--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -391,13 +391,21 @@
 	component.purgeTrash = function purgeTrash() {
 		api.section.each( function( section ) {
 			if ( section.extended( component.PostSection ) && 'trash' === api( section.id ).get().post_status ) {
-				api.section.remove( section.id );
 				section.active.set( false );
 				section.collapse();
+				_.each( section.controls(), function( control ) {
+					control.container.remove();
+					api.control.remove( control.id );
+				} );
+				api.section.remove( section.id );
 				section.container.remove();
 				if ( true === component.previewedQuery.get().isSingular ) {
 					api.previewer.previewUrl( api.settings.url.home );
 				}
+
+				// @todo Also remove all postmeta settings for this post?
+				api.remove( section.id );
+				delete component.fetchedPosts[ section.params.post_id ];
 			}
 		} );
 	};

--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -300,6 +300,12 @@
 					previewer: api.previewer
 				} );
 
+				// Mark as dirty and trigger change if setting is pre-dirty; see code in wp.customize.Value.prototype.set().
+				if ( settingArgs.dirty ) {
+					setting._dirty = true;
+					setting.callbacks.fireWith( setting, [ setting.get(), setting.get() ] );
+				}
+
 				/*
 				 * Ensure that the setting gets created in the preview as well. When the post/postmeta settings
 				 * are sent to the preview, this is the point at which the related selective refresh partials

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -331,7 +331,7 @@ class Customize_Posts_Plugin {
 
 		$handle = 'customize-posts';
 		$src = plugins_url( 'css/customize-posts' . $suffix, dirname( __FILE__ ) );
-		$deps = array( 'wp-admin' );
+		$deps = array( 'wp-admin', 'select2' );
 		$version = $this->version;
 		$wp_styles->add( $handle, $src, $deps, $version );
 

--- a/php/class-customize-posts-support.php
+++ b/php/class-customize-posts-support.php
@@ -33,12 +33,8 @@ abstract class Customize_Posts_Support {
 	 * @access public
 	 *
 	 * @param WP_Customize_Posts $posts_component Component.
-	 * @throws Exception If the Posts component is not instantiated.
 	 */
 	public function __construct( WP_Customize_Posts $posts_component ) {
-		if ( empty( $posts_component ) || ! ( $posts_component instanceof WP_Customize_Posts ) ) {
-			throw new Exception( 'Posts component not instantiated.' );
-		}
 		$this->posts_component = $posts_component;
 	}
 

--- a/php/class-wp-customize-featured-image-controller.php
+++ b/php/class-wp-customize-featured-image-controller.php
@@ -393,7 +393,7 @@ class WP_Customize_Featured_Image_Controller extends WP_Customize_Postmeta_Contr
 			||
 			-1 === $attachment_id
 			||
-			( is_int( $attachment_id ) && $attachment_id > 0 )
+			( is_int( $attachment_id ) && $attachment_id >= 0 )
 		);
 
 		/*

--- a/php/class-wp-customize-post-date-control.php
+++ b/php/class-wp-customize-post-date-control.php
@@ -19,6 +19,14 @@ class WP_Customize_Post_Date_Control extends WP_Customize_Dynamic_Control {
 	public $posts_component;
 
 	/**
+	 * Type of control, used by JS.
+	 *
+	 * @access public
+	 * @var string
+	 */
+	public $type = 'post_date';
+
+	/**
 	 * Constructor.
 	 *
 	 * @throws Exception If posts component not available.
@@ -36,12 +44,11 @@ class WP_Customize_Post_Date_Control extends WP_Customize_Dynamic_Control {
 	}
 
 	/**
-	 * Type of control, used by JS.
-	 *
-	 * @access public
-	 * @var string
+	 * Enqueue control related scripts/styles.
 	 */
-	public $type = 'post_date';
+	public function enqueue() {
+		wp_enqueue_script( 'customize-post-date-control' );
+	}
 
 	/**
 	 * Render the Underscore template for this control.

--- a/php/class-wp-customize-post-setting.php
+++ b/php/class-wp-customize-post-setting.php
@@ -526,6 +526,9 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 	 * Please note that the capability check will have already been done.
 	 *
 	 * @see WP_Customize_Setting::save()
+	 * @see wp_update_post()
+	 * @see wp_trash_post()
+	 * @see wp_untrash_post()
 	 *
 	 * @param string $data The value to update.
 	 * @return bool The result of saving the value.
@@ -542,7 +545,10 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 		$data = $this->augment_gmt_dates( $data );
 
 		$is_trashed = 'trash' === $data['post_status'];
+		$was_trashed = 'trash' === get_post_status( $this->post_id );
 		$is_auto_draft = in_array( get_post_status( $this->post_id ), array( 'auto-draft', 'customize-draft' ), true );
+		$transition_to_trash = $is_trashed && ! $was_trashed;
+		$transition_from_trash = ! $is_trashed && $was_trashed;
 
 		// If trashing an auto-draft, just delete it straight-away and short-circuit.
 		if ( $is_trashed && $is_auto_draft ) {
@@ -574,6 +580,15 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 			add_filter( 'wp_insert_post_data', array( $this->posts_component, 'force_empty_post_dates' ) );
 			add_filter( 'wp_insert_attachment_data', array( $this->posts_component, 'force_empty_post_dates' ) );
 		}
+
+		if ( $transition_from_trash ) {
+			/** This action is documented in wp-includes/post.php */
+			do_action( 'untrash_post', $this->post_id );
+
+			// Ensure that the post_name supplied in the setting will be used.
+			delete_post_meta( $this->post_id, '_wp_desired_post_slug' );
+		}
+
 		$r = wp_update_post( wp_slash( $data ), true );
 		if ( $should_store_empty_date ) {
 			remove_filter( 'wp_insert_post_data', array( $this->posts_component, 'force_empty_post_dates' ) );
@@ -581,9 +596,17 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 		}
 		$result = ! is_wp_error( $r );
 
-		if ( $is_trashed ) {
+		if ( $transition_to_trash ) {
 			$result = wp_trash_post( $this->post_id );
 			remove_filter( 'wp_insert_post_empty_content', '__return_false', 100 );
+		} elseif ( $transition_from_trash ) {
+			wp_untrash_post_comments( $this->post_id );
+
+			/** This action is documented in wp-includes.php */
+			do_action( 'untrashed_post', $this->post_id );
+
+			delete_post_meta( $this->post_id, '_wp_trash_meta_status' );
+			delete_post_meta( $this->post_id, '_wp_trash_meta_time' );
 		}
 
 		return $result;

--- a/php/class-wp-customize-post-setting.php
+++ b/php/class-wp-customize-post-setting.php
@@ -599,7 +599,9 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 		if ( $transition_to_trash ) {
 			$result = wp_trash_post( $this->post_id );
 			remove_filter( 'wp_insert_post_empty_content', '__return_false', 100 );
-		} elseif ( $transition_from_trash ) {
+		}
+
+		if ( $transition_from_trash ) {
 			wp_untrash_post_comments( $this->post_id );
 
 			/** This action is documented in wp-includes.php */

--- a/php/class-wp-customize-post-status-control.php
+++ b/php/class-wp-customize-post-status-control.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Customize Post Status Control Class
+ *
+ * @package WordPress
+ * @subpackage Customize
+ */
+
+/**
+ * Class WP_Customize_Post_Status_Control
+ */
+class WP_Customize_Post_Status_Control extends WP_Customize_Dynamic_Control {
+
+	/**
+	 * Posts component.
+	 *
+	 * @var WP_Customize_Posts
+	 */
+	public $posts_component;
+
+	/**
+	 * Type of control, used by JS.
+	 *
+	 * @access public
+	 * @var string
+	 */
+	public $type = 'post_status';
+
+	/**
+	 * Constructor.
+	 *
+	 * @throws Exception If posts component not available.
+	 *
+	 * @param WP_Customize_Manager $manager Manager.
+	 * @param string               $id      Control id.
+	 * @param array                $args    Control args.
+	 */
+	public function __construct( WP_Customize_Manager $manager, $id, array $args ) {
+		if ( ! isset( $manager->posts ) || ! ( $manager->posts instanceof WP_Customize_Posts ) ) {
+			throw new Exception( 'Missing Posts component.' );
+		}
+		$this->posts_component = $manager->posts;
+		parent::__construct( $manager, $id, $args );
+	}
+
+	/**
+	 * Enqueue control related scripts/styles.
+	 */
+	public function enqueue() {
+		wp_enqueue_script( 'customize-post-status-control' );
+	}
+
+	/**
+	 * Render the Underscore template for this control.
+	 *
+	 * @access protected
+	 * @codeCoverageIgnore
+	 */
+	protected function content_template() {
+		$data = $this->json();
+		?>
+		<#
+		_.defaults( data, <?php echo wp_json_encode( $data ) ?> );
+		data.input_id = 'input-' + String( Math.random() );
+		#>
+		<span class="customize-control-title"><label for="{{ data.input_id }}">{{ data.label }}</label></span>
+		<# if ( data.description ) { #>
+			<span class="description customize-control-description">{{ data.description }}</span>
+		<# } #>
+		<select id="{{ data.input_id }}"
+			<# _.each( data.input_attrs, function( value, key ) { #>
+				{{{ key }}}="{{ value }}"
+			<# } ) #>
+			<# if ( data.setting_property ) { #>
+				data-customize-setting-property-link="{{ data.setting_property }}"
+			<# } #>
+			>
+			<# _.each( data.choices, function( choice ) { #>
+				<#
+				if ( _.isObject( choice ) && ! _.isUndefined( choice.text ) && ! _.isUndefined( choice.value ) ) {
+					text = choice.text;
+					value = choice.value;
+				}
+				#>
+				<option value="{{ value }}">{{ text }}</option>
+			<# } ); #>
+		</select>
+		<a class="trash" href="javascript:void(0)"><?php esc_html_e( 'Move to Trash', 'customize-posts' ) ?></a>
+		<?php
+	}
+}

--- a/php/class-wp-customize-post-status-control.php
+++ b/php/class-wp-customize-post-status-control.php
@@ -86,6 +86,7 @@ class WP_Customize_Post_Status_Control extends WP_Customize_Dynamic_Control {
 			<# } ); #>
 		</select>
 		<a class="trash" href="javascript:void(0)"><?php esc_html_e( 'Move to Trash', 'customize-posts' ) ?></a>
+		<a class="untrash" href="javascript:void(0)"><?php esc_html_e( 'Undo Trash', 'customize-posts' ) ?></a>
 		<?php
 	}
 }

--- a/php/class-wp-customize-posts-panel.php
+++ b/php/class-wp-customize-posts-panel.php
@@ -87,7 +87,10 @@ class WP_Customize_Posts_Panel extends WP_Customize_Panel {
 			<# if ( data.featured_image && data.featured_image.sizes && data.featured_image.sizes.thumbnail && data.featured_image.sizes.thumbnail.url ) { #>
 				<img class="customize-posts-select2-thumbnail" src="{{ data.featured_image.sizes.thumbnail.url }}">
 			<# } #>
-			<# if ( data.text ) { #>
+			<# if ( data.status && 'trash' === data.status ) { #>
+				<em><?php esc_html_e( '[Trashed]', 'customize-posts' ) ?></em>
+				<span class="trashed-title">{{ data.title }}</span>
+			<# } else if ( data.text ) { #>
 				{{ data.text }}
 			<# } else { #>
 				<em><?php esc_html_e( '(No title)', 'customize-posts' ); ?></em>

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -1150,6 +1150,9 @@ final class WP_Customize_Posts {
 				get_post_stati( array( 'public' => true ) )
 			);
 		}
+		if ( isset( $post_type_obj->cap->delete_posts ) && current_user_can( $post_type_obj->cap->delete_posts ) ) {
+			$query_args['post_status'][] = 'trash';
+		}
 		if ( isset( $post_type_obj->cap->edit_others_posts ) || ! current_user_can( $post_type_obj->cap->edit_others_posts ) ) {
 			$query_args['post_author'] = get_current_user_id();
 		}

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -556,6 +556,11 @@ final class WP_Customize_Posts {
 	 * @return array
 	 */
 	public function filter_customize_save_response_to_export_saved_values( $response ) {
+		// Short circuit if there there were invalidities.
+		if ( isset( $response['setting_validities'] ) && count( array_filter( $response['setting_validities'], 'is_array' ) ) > 0 ) {
+			return $response;
+		}
+
 		$response['saved_post_setting_values'] = array();
 		foreach ( array_keys( $this->manager->unsanitized_post_values() ) as $setting_id ) {
 			$setting = $this->manager->get_setting( $setting_id );

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -831,7 +831,7 @@ final class WP_Customize_Posts {
 	 * @access public
 	 */
 	public function preview_customize_draft_post_ids() {
-		if ( isset( $_REQUEST['preview'] ) ) {
+		if ( isset( $_REQUEST['preview'] ) ) { // @todo Why not look at $wp_query->is_preview()?
 			$this->customize_draft_post_ids = array();
 			foreach ( $this->manager->unsanitized_post_values() as $id => $post_data ) {
 				if ( ! preg_match( WP_Customize_Post_Setting::SETTING_ID_PATTERN, $id, $matches ) ) {

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -564,7 +564,7 @@ final class WP_Customize_Posts {
 		$response['saved_post_setting_values'] = array();
 		foreach ( array_keys( $this->manager->unsanitized_post_values() ) as $setting_id ) {
 			$setting = $this->manager->get_setting( $setting_id );
-			if ( $setting instanceof WP_Customize_Post_Setting || $setting instanceof WP_Customize_Postmeta_Setting ) {
+			if ( ( $setting instanceof WP_Customize_Post_Setting || $setting instanceof WP_Customize_Postmeta_Setting ) && get_post( $setting->post_id ) ) {
 				$response['saved_post_setting_values'][ $setting->id ] = $setting->js_value();
 			}
 		}

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -81,6 +81,7 @@ final class WP_Customize_Posts {
 		require_once dirname( __FILE__ ) . '/class-wp-customize-post-setting.php';
 		require_once dirname( __FILE__ ) . '/class-wp-customize-postmeta-setting.php';
 		require_once dirname( __FILE__ ) . '/class-wp-customize-post-date-control.php';
+		require_once dirname( __FILE__ ) . '/class-wp-customize-post-status-control.php';
 		require_once ABSPATH . WPINC . '/customize/class-wp-customize-partial.php';
 		require_once dirname( __FILE__ ) . '/class-wp-customize-post-field-partial.php';
 
@@ -287,6 +288,7 @@ final class WP_Customize_Posts {
 		$this->manager->register_control_type( 'WP_Customize_Dynamic_Control' );
 		$this->manager->register_control_type( 'WP_Customize_Post_Discussion_Fields_Control' );
 		$this->manager->register_control_type( 'WP_Customize_Post_Date_Control' );
+		$this->manager->register_control_type( 'WP_Customize_Post_Status_Control' );
 
 		$panel_priority = 900; // Before widgets.
 

--- a/tests/php/test-ajax-class-wp-customize-posts.php
+++ b/tests/php/test-ajax-class-wp-customize-posts.php
@@ -401,6 +401,9 @@ class Test_Ajax_WP_Customize_Posts extends WP_Ajax_UnitTestCase {
 	 */
 	public function test_ajax_posts_select2_query_successes() {
 		$this->factory()->post->create_many( 30 );
+		$draft_post_id = $this->factory()->post->create( array( 'post_status' => 'draft', 'post_date' => gmdate( 'Y-m-d H:i:s', time() + 60 ) ) );
+		$private_post_id = $this->factory()->post->create( array( 'post_status' => 'private', 'post_date' => gmdate( 'Y-m-d H:i:s', time() + 2 * 60 ) ) );
+		$trashed_post_id = $this->factory()->post->create( array( 'post_status' => 'trash', 'post_date' => gmdate( 'Y-m-d H:i:s', time() + 3 * 60 ) ) );
 
 		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'administrator' ) ) );
 		$_POST = wp_slash( array(
@@ -419,6 +422,10 @@ class Test_Ajax_WP_Customize_Posts extends WP_Ajax_UnitTestCase {
 		$this->assertArrayHasKey( 'featured_image', $first_item );
 		$this->assertTrue( $response['data']['pagination']['more'] );
 		$this->_last_response = '';
+
+		$this->assertEquals( $trashed_post_id, $response['data']['results'][0]['id'] );
+		$this->assertEquals( $private_post_id, $response['data']['results'][1]['id'] );
+		$this->assertEquals( $draft_post_id, $response['data']['results'][2]['id'] );
 
 		$_POST = wp_slash( array(
 			'customize-posts-nonce' => wp_create_nonce( 'customize-posts' ),

--- a/tests/php/test-class-wp-customize-post-date-control.php
+++ b/tests/php/test-class-wp-customize-post-date-control.php
@@ -62,11 +62,17 @@ class Test_WP_Customize_Post_Date_Control extends WP_UnitTestCase {
 	 * Test constructor when posts component doesn't exists.
 	 *
 	 * @covers WP_Customize_Post_Date_Control::__construct()
-	 * @expectedException Exception
 	 */
 	public function test_construct_without_posts_component() {
 		$this->wp_customize->posts = null;
-		new WP_Customize_Post_Date_Control( $this->wp_customize, $this->setting_id . '[post_date]', array() );
+		$exception = null;
+		try {
+			new WP_Customize_Post_Date_Control( $this->wp_customize, $this->setting_id . '[post_date]', array() );
+		} catch ( Exception $e ) {
+			$exception = $e;
+		}
+		$this->assertInstanceOf( 'Exception', $exception );
+		$this->assertEquals( 'Missing Posts component.', $exception->getMessage() );
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-post-setting.php
+++ b/tests/php/test-class-wp-customize-post-setting.php
@@ -698,6 +698,15 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test update() for untrashing.
+	 *
+	 * @see WP_Customize_Post_Setting::update()
+	 */
+	function test_save_untrash() {
+		$this->markTestIncomplete();
+	}
+
+	/**
 	 * Test update() for trashing auto-draft posts (which means delete).
 	 *
 	 * @see WP_Customize_Post_Setting::update()

--- a/tests/php/test-class-wp-customize-post-setting.php
+++ b/tests/php/test-class-wp-customize-post-setting.php
@@ -771,7 +771,7 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 	/**
 	 * Handle untrash_post action.
 	 *
-	 * @param $post_id Post ID.
+	 * @param int $post_id Post ID.
 	 */
 	function handle_action_untrash_post( $post_id ) {
 		$this->untrash_post_id = $post_id;
@@ -780,7 +780,7 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 	/**
 	 * Handle untrashed_post action.
 	 *
-	 * @param $post_id Post ID.
+	 * @param int $post_id Post ID.
 	 */
 	function handle_action_untrashed_post( $post_id ) {
 		$this->untrashed_post_id = $post_id;
@@ -815,7 +815,7 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 	/**
 	 * Trashed post ID.
 	 *
-	 * @var int
+	 * @var int Trashed post ID.
 	 */
 	public $trashed_post_id;
 

--- a/tests/php/test-class-wp-customize-post-setting.php
+++ b/tests/php/test-class-wp-customize-post-setting.php
@@ -60,6 +60,9 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 		$this->wp_customize = null;
 		unset( $_POST['customized'] );
 		unset( $GLOBALS['wp_customize'] );
+		$this->trashed_post_id = null;
+		$this->untrash_post_id = null;
+		$this->untrashed_post_id = null;
 		parent::tearDown();
 	}
 
@@ -562,7 +565,6 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 		$this->assertEquals( 'publish', $sanitized['post_status'] );
 	}
 
-
 	/**
 	 * Test preview().
 	 *
@@ -672,12 +674,13 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 	/**
 	 * Test update() for trashing.
 	 *
-	 * @see WP_Customize_Post_Setting::update()
+	 * @covers WP_Customize_Post_Setting::update()
 	 */
 	function test_save_trash() {
 		add_action( 'trashed_post', array( $this, 'handle_action_trashed_post' ) );
 		$original_data = array(
 			'post_title' => 'Food',
+			'post_name' => 'food',
 		);
 		$setting = $this->create_post_setting( $original_data );
 
@@ -695,15 +698,92 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 		$this->assertEquals( 'trash', $post->post_status );
 		$this->assertEquals( $setting->post_id, $this->trashed_post_id );
 		$this->assertEquals( $trash_post_count + 1, did_action( 'trashed_post' ) );
+		$this->assertEquals( 'food__trashed', $post->post_name );
+		$this->assertEquals( 'food', get_post_meta( $post->ID, '_wp_desired_post_slug', true ) );
 	}
+
+	/**
+	 * Arg passed to untrash_post action.
+	 *
+	 * @var int
+	 */
+	public $untrash_post_id;
+
+	/**
+	 * Arg passed to untrashed_post action.
+	 *
+	 * @var int
+	 */
+	public $untrashed_post_id;
 
 	/**
 	 * Test update() for untrashing.
 	 *
-	 * @see WP_Customize_Post_Setting::update()
+	 * @covers WP_Customize_Post_Setting::update()
 	 */
 	function test_save_untrash() {
-		$this->markTestIncomplete();
+		add_action( 'untrash_post', array( $this, 'handle_action_untrash_post' ) );
+		add_action( 'untrashed_post', array( $this, 'handle_action_untrashed_post' ) );
+		$post_id = $this->factory()->post->create( array( 'post_status' => 'private', 'post_name' => 'foo' ) );
+		$comment_id = wp_insert_comment( array(
+			'comment_post_ID' => $post_id,
+			'comment_content' => 'Comment',
+			'comment_approved' => '1',
+		) );
+
+		wp_trash_post( $post_id );
+		$setting_id = WP_Customize_Post_Setting::get_post_setting_id( get_post( $post_id ) );
+		$this->posts_component->manager->add_dynamic_settings( array( $setting_id ) );
+		$setting = $this->posts_component->manager->get_setting( $setting_id );
+		$this->assertInstanceOf( 'WP_Customize_Post_Setting', $setting );
+		$trashed_value = $setting->value();
+		$this->assertEquals( 'foo__trashed', $trashed_value['post_name'] );
+		$this->assertEquals( 'trash', $trashed_value['post_status'] );
+		$this->posts_component->manager->set_post_value( $setting_id, array_merge(
+			$setting->value(),
+			array(
+				'post_status' => 'private',
+				'post_name' => 'foo',
+			)
+		) );
+
+		$this->assertEquals( 'foo', get_post_meta( $post_id, '_wp_desired_post_slug', true ) );
+		$this->assertEquals( 'private', get_post_meta( $post_id, '_wp_trash_meta_status', true ) );
+		$this->assertNotEmpty( get_post_meta( $post_id, '_wp_trash_meta_time', true ) );
+		$this->assertNotEmpty( get_post_meta( $post_id, '_wp_trash_meta_comments_status', true ) );
+		$this->assertNull( $this->untrash_post_id );
+		$this->assertNull( $this->untrashed_post_id );
+		$this->assertEquals( 'trash', get_post_status( $post_id ) );
+		$this->assertEquals( 'foo__trashed', get_post( $post_id )->post_name );
+		$this->assertEquals( 'post-trashed', get_comment( $comment_id )->comment_approved );
+		$setting->save();
+		$this->assertEquals( 'private', get_post_status( $post_id ) );
+		$this->assertEquals( 'foo', get_post( $post_id )->post_name );
+		$this->assertEquals( $post_id, $this->untrash_post_id );
+		$this->assertEquals( $post_id, $this->untrashed_post_id );
+		$this->assertEmpty( get_post_meta( $post_id, '_wp_desired_post_slug', true ) );
+		$this->assertEmpty( get_post_meta( $post_id, '_wp_trash_meta_status', true ) );
+		$this->assertEmpty( get_post_meta( $post_id, '_wp_trash_meta_time', true ) );
+		$this->assertEmpty( get_post_meta( $post_id, '_wp_trash_meta_comments_status', true ) );
+		$this->assertEquals( '1', get_comment( $comment_id )->comment_approved );
+	}
+
+	/**
+	 * Handle untrash_post action.
+	 *
+	 * @param $post_id Post ID.
+	 */
+	function handle_action_untrash_post( $post_id ) {
+		$this->untrash_post_id = $post_id;
+	}
+
+	/**
+	 * Handle untrashed_post action.
+	 *
+	 * @param $post_id Post ID.
+	 */
+	function handle_action_untrashed_post( $post_id ) {
+		$this->untrashed_post_id = $post_id;
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-post-status-control.php
+++ b/tests/php/test-class-wp-customize-post-status-control.php
@@ -62,11 +62,17 @@ class Test_WP_Customize_Post_Status_Control extends WP_UnitTestCase {
 	 * Test constructor when posts component doesn't exists.
 	 *
 	 * @covers WP_Customize_Post_Status_Control::__construct()
-	 * @expectedException Exception
 	 */
 	public function test_construct_without_posts_component() {
 		$this->wp_customize->posts = null;
-		new WP_Customize_Post_Status_Control( $this->wp_customize, $this->setting_id . '[post_date]', array() );
+		$exception = null;
+		try {
+			new WP_Customize_Post_Status_Control( $this->wp_customize, $this->setting_id . '[post_status]', array() );
+		} catch ( Exception $e ) {
+			$exception = $e;
+		}
+		$this->assertInstanceOf( 'Exception', $exception );
+		$this->assertEquals( 'Missing Posts component.', $exception->getMessage() );
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-post-status-control.php
+++ b/tests/php/test-class-wp-customize-post-status-control.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Tests for Test_WP_Customize_Post_Date_Control.
+ * Tests for Test_WP_Customize_Post_Status_Control.
  *
  * @package WordPress
  * @subpackage Customize
  */
 
 /**
- * Class Test_WP_Customize_Post_Date_Control
+ * Class Test_WP_Customize_Post_Status_Control
  */
-class Test_WP_Customize_Post_Date_Control extends WP_UnitTestCase {
+class Test_WP_Customize_Post_Status_Control extends WP_UnitTestCase {
 
 	/**
 	 * Customize Manager instance.
@@ -61,35 +61,35 @@ class Test_WP_Customize_Post_Date_Control extends WP_UnitTestCase {
 	/**
 	 * Test constructor when posts component doesn't exists.
 	 *
-	 * @covers WP_Customize_Post_Date_Control::__construct()
+	 * @covers WP_Customize_Post_Status_Control::__construct()
 	 * @expectedException Exception
 	 */
 	public function test_construct_without_posts_component() {
 		$this->wp_customize->posts = null;
-		new WP_Customize_Post_Date_Control( $this->wp_customize, $this->setting_id . '[post_date]', array() );
+		new WP_Customize_Post_Status_Control( $this->wp_customize, $this->setting_id . '[post_date]', array() );
 	}
 
 	/**
 	 * Test constructor when posts component does exists.
 	 *
-	 * @covers WP_Customize_Post_Date_Control::__construct()
+	 * @covers WP_Customize_Post_Status_Control::__construct()
 	 */
 	public function test_construct_with_posts_component() {
-		$control = new WP_Customize_Post_Date_Control( $this->wp_customize, $this->setting_id . '[post_date]', array() );
+		$control = new WP_Customize_Post_Status_Control( $this->wp_customize, $this->setting_id . '[post_status]', array() );
 		$this->assertEquals( $this->posts, $control->posts_component );
 	}
 
 	/**
 	 * Test enqueue.
 	 *
-	 * @covers WP_Customize_Post_Date_Control::enqueue()
+	 * @covers WP_Customize_Post_Status_Control::enqueue()
 	 */
 	public function test_enqueue() {
-		$control = new WP_Customize_Post_Date_Control( $this->wp_customize, $this->setting_id . '[post_date]', array() );
-		$this->assertNotEmpty( wp_scripts()->query( 'customize-post-date-control', 'registered' ) );
-		$this->assertFalse( wp_scripts()->query( 'customize-post-date-control', 'enqueued' ) );
+		$control = new WP_Customize_Post_Status_Control( $this->wp_customize, $this->setting_id . '[post_status]', array() );
+		$this->assertNotEmpty( wp_scripts()->query( 'customize-post-status-control', 'registered' ) );
+		$this->assertFalse( wp_scripts()->query( 'customize-post-status-control', 'enqueued' ) );
 		$control->enqueue();
-		$this->assertTrue( wp_scripts()->query( 'customize-post-date-control', 'enqueued' ) );
+		$this->assertTrue( wp_scripts()->query( 'customize-post-status-control', 'enqueued' ) );
 	}
 
 	/**
@@ -98,13 +98,13 @@ class Test_WP_Customize_Post_Date_Control extends WP_UnitTestCase {
 	 * @covers WP_Customize_Dynamic_Control::json()
 	 */
 	public function test_json() {
-		$control = new WP_Customize_Post_Date_Control( $this->wp_customize, 'post[post][123][post_date]', array(
+		$control = new WP_Customize_Post_Status_Control( $this->wp_customize, $this->setting_id . '[post_status]', array(
 			'label'            => 'Heading Text',
 			'section'          => $this->setting_id,
 			'settings'         => $this->setting_id,
 			'priority'         => 1,
-			'field_type'       => 'post_date',
-			'setting_property' => 'post_date',
+			'field_type'       => 'post_status',
+			'setting_property' => 'post_status',
 			'input_attrs'      => array( 'data-test' => 'value-test' ),
 		) );
 		$json = $control->json();
@@ -113,7 +113,7 @@ class Test_WP_Customize_Post_Date_Control extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'field_type', $json );
 		$this->assertArrayHasKey( 'setting_property', $json );
 		$this->assertEquals( array( 'data-test' => 'value-test' ), $json['input_attrs'] );
-		$this->assertEquals( 'post_date', $json['field_type'] );
-		$this->assertEquals( 'post_date', $json['setting_property'] );
+		$this->assertEquals( 'post_status', $json['field_type'] );
+		$this->assertEquals( 'post_status', $json['setting_property'] );
 	}
 }

--- a/tests/php/test-class-wp-customize-posts.php
+++ b/tests/php/test-class-wp-customize-posts.php
@@ -317,7 +317,7 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 	/**
 	 * Tests get_post_status_choices().
 	 *
-	 * @covers WP_Customize_Posts::get_post_status_choices().
+	 * @covers WP_Customize_Posts::get_post_status_choices()
 	 */
 	public function test_get_post_status_choices() {
 		$posts = new WP_Customize_Posts( $this->wp_customize );
@@ -334,7 +334,7 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 	/**
 	 * Tests get_author_choices().
 	 *
-	 * @covers WP_Customize_Posts::get_author_choices().
+	 * @covers WP_Customize_Posts::get_author_choices()
 	 */
 	public function test_get_author_choices() {
 		$posts = new WP_Customize_Posts( $this->wp_customize );

--- a/tests/php/test-class-wp-customize-posts.php
+++ b/tests/php/test-class-wp-customize-posts.php
@@ -672,7 +672,24 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 	 * @covers WP_Customize_Posts::get_settings()
 	 */
 	public function test_get_settings() {
-		$this->markTestIncomplete();
+		$published_post_id = $this->factory()->post->create( array( 'post_status' => 'publish', 'post_name' => 'foo' ) );
+		$trashed_post_id = $this->factory()->post->create( array( 'post_status' => 'private', 'post_name' => 'bar' ) );
+		$draft_page_id = $this->factory()->post->create( array( 'post_status' => 'draft', 'post_name' => 'quux', 'post_type' => 'page' ) );
+		$this->posts->register_post_type_meta( 'post', 'baz' );
+		wp_trash_post( $trashed_post_id );
+
+		$settings_params = $this->posts->get_settings( array( $published_post_id, $trashed_post_id, $draft_page_id ) );
+		$this->assertCount( 5, $settings_params );
+		$this->assertEqualSets(
+			array(
+				WP_Customize_Post_Setting::get_post_setting_id( get_post( $published_post_id ) ),
+				WP_Customize_Post_Setting::get_post_setting_id( get_post( $trashed_post_id ) ),
+				WP_Customize_Post_Setting::get_post_setting_id( get_post( $draft_page_id ) ),
+				WP_Customize_Postmeta_Setting::get_post_meta_setting_id( get_post( $published_post_id ), 'baz' ),
+				WP_Customize_Postmeta_Setting::get_post_meta_setting_id( get_post( $trashed_post_id ), 'baz' )
+			),
+			array_keys( $settings_params )
+		);
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-posts.php
+++ b/tests/php/test-class-wp-customize-posts.php
@@ -516,6 +516,15 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests preview_customize_draft_post_ids().
+	 *
+	 * @covers WP_Customize_Posts::preview_customize_draft_post_ids()
+	 */
+	public function test_preview_customize_draft_post_ids() {
+		$this->markTestIncomplete();
+	}
+
+	/**
 	 * Test preview_customize_draft method.
 	 *
 	 * @see WP_Customize_Posts::preview_customize_draft()
@@ -572,6 +581,18 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Check filtering the post link in the preview.
+	 *
+	 * @see WP_Customize_Posts::post_link_draft()]
+	 */
+	public function test_post_link_draft() {
+		global $wp_customize;
+		$this->assertNotContains( 'preview=true', get_permalink( $this->post_id ) );
+		$wp_customize->start_previewing_theme();
+		$this->assertContains( 'preview=true', get_permalink( $this->post_id ) );
+	}
+
+	/**
 	 * Test insert_auto_draft_post method.
 	 *
 	 * @see WP_Customize_Posts::insert_auto_draft_post()
@@ -618,16 +639,24 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Check filtering the post link in the preview.
+	 * Tests get_settings().
 	 *
-	 * @see WP_Customize_Posts::post_link_draft()]
+	 * @covers WP_Customize_Posts::get_settings()
 	 */
-	public function test_post_link_draft() {
-		global $wp_customize;
-		$this->assertNotContains( 'preview=true', get_permalink( $this->post_id ) );
-		$wp_customize->start_previewing_theme();
-		$this->assertContains( 'preview=true', get_permalink( $this->post_id ) );
+	public function test_get_settings() {
+		$this->markTestIncomplete();
 	}
+
+	/**
+	 * Tests get_setting_param().
+	 *
+	 * @covers WP_Customize_Posts::get_setting_param()
+	 */
+	public function test_get_setting_params() {
+		$this->markTestIncomplete();
+	}
+
+	// See Ajax tests in test-ajax-class-wp-customize-posts.php
 
 	/**
 	 * Test get_select2_item_result.

--- a/tests/php/test-class-wp-customize-posts.php
+++ b/tests/php/test-class-wp-customize-posts.php
@@ -351,7 +351,7 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 	/**
 	 * Get month choices.
 	 *
-	 * @covers WP_Customize_Dynamic_Control::get_date_month_choices()
+	 * @covers WP_Customize_Posts::get_date_month_choices()
 	 */
 	public function test_get_date_month_choices() {
 		$posts = new WP_Customize_Posts( $this->wp_customize );


### PR DESCRIPTION
* Adds custom control template for post status control
* Introduces “Move to Trash” link that appears next to dropdown which appears when the status is not `trash`.
* Clicking the “Move to Trash” link sets the setting's `post_status` property to `trash` and then collapses the post section, to add a similar experience to clicking this same link on the edit post admin screen where clicking the link moves the user to the post list table. The collapse is done after a half-second delay to show the user that clicking the link just changes the dropdown, giving them a clue to restore the post by changing the status back to something other than `trash`.
* The post can be untrashed simply by re-expanding the section and changing the status to a non-trash status.

<img width="287" alt="screen shot 2016-08-04 at 1 26 32 pm" src="https://cloud.githubusercontent.com/assets/134745/17417463/5da0fa9a-5a48-11e6-9d33-8c25640c3917.png">

<img width="283" alt="screen shot 2016-08-04 at 1 26 46 pm" src="https://cloud.githubusercontent.com/assets/134745/17417462/5d9e84c2-5a48-11e6-8fc7-710c38d0c223.png">

Fixes #172.