### PR TITLE
Line up `number` inputs in post date selection.

### DIFF
--- a/css/customize-posts.css
+++ b/css/customize-posts.css
@@ -264,20 +264,56 @@ body.customize-posts-content-editor-pane-resize #customize-preview:before {
 }
 .customize-control-post_date .date-inputs {
 	clear: both;
+	display: -webkit-box;
+	display: -ms-flexbox;
+	display: flex;
+	-webkit-box-align: baseline;
+	-ms-flex-align: baseline;
+	align-items: baseline;
+	-webkit-box-pack: justify;
+	-ms-flex-pack: justify;
+	justify-content: space-between;
 }
 
 .customize-control-post_date select,
 .customize-control-post_date input.date-input {
-	min-width: 10%;
-	width: auto;
+	width: 12%;
+	min-width: 12%;
+	-ms-flex-preferred-size: 8%;
+	flex-basis: 8%;
+}
+.customize-control-post_date select {
+	width: 30%;
+	-ms-flex-preferred-size: 25%;
+	flex-basis: 12%;
+	-webkit-box-flex: 6;
+	-ms-flex-positive: 6;
+	flex-grow: 6;
+}
+@media screen and ( max-width: 782px ) {
+	.customize-control-post_date select {
+		height: 40px;
+	}
 }
 .customize-control-post_date input.date-input {
+	display: inline-block;
+	-webkit-box-flex: 2;
+	-ms-flex-positive: 2;
+	flex-grow: 2;
 	-moz-appearance: textfield;
 }
 .customize-control-post_date input.date-input::-webkit-outer-spin-button,
 .customize-control-post_date input.date-input::-webkit-inner-spin-button {
 	-webkit-appearance: none;
 	margin: 0;
+}
+.customize-control-post_date input.date-input.year {
+	width: 18%;
+	-ms-flex-preferred-size: 15%;
+	flex-basis: 10%;
+	-webkit-box-flex: 4;
+	-ms-flex-positive: 4;
+	flex-grow: 4;
 }
 .wrap-reset-time {
 	font-weight: normal;


### PR DESCRIPTION
@westonruter - I've fixed `number` inputs display on Firefox. Tested on Firefox, Chrome (Mac OS/Win) and IE (9, 10, 11).

I've noticed that @sayedwp worked on the same issue in #212. I had no time to look into it, but it might be a better solution than mine.

I haven't got a chance to work on `details` element. It doesn't work on only on FF, but also on IE 9, 10 and 11.