### PR TITLE
Ensure wp_insert_post_empty_content filter gets removed after trashing

### DIFF
--- a/php/class-wp-customize-post-setting.php
+++ b/php/class-wp-customize-post-setting.php
@@ -598,6 +598,9 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 
 		if ( $transition_to_trash ) {
 			$result = wp_trash_post( $this->post_id );
+		}
+
+		if ( $is_trashed ) {
 			remove_filter( 'wp_insert_post_empty_content', '__return_false', 100 );
 		}
 


### PR DESCRIPTION
The filter gets added if `$is_trashed` so this should be the condition for removal as well.