### PR TITLE
Attempt to enable translating via translate.wordpress.org

### DIFF
--- a/customize-posts.php
+++ b/customize-posts.php
@@ -8,6 +8,7 @@
  * Author URI: https://make.xwp.co/
  * License: GPLv2+
  * Text Domain: customize-posts
+ * Domain Path: /languages
  *
  * Copyright (c) 2016 XWP (https://xwp.co/)
  *

--- a/customize-posts.php
+++ b/customize-posts.php
@@ -8,7 +8,6 @@
  * Author URI: https://make.xwp.co/
  * License: GPLv2+
  * Text Domain: customize-posts
- * Domain Path: /languages
  *
  * Copyright (c) 2016 XWP (https://xwp.co/)
  *

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -52,6 +52,8 @@ class Customize_Posts_Plugin {
 			return;
 		}
 
+		load_plugin_textdomain( 'customize-posts' );
+
 		// Parse plugin version.
 		if ( preg_match( '/Version:\s*(\S+)/', file_get_contents( dirname( __FILE__ ) . '/../customize-posts.php' ), $matches ) ) {
 			$this->version = $matches[1];


### PR DESCRIPTION
We're currently not able to make use of translate.wordpress.org for translating the plugin. It [reports](https://translate.wordpress.org/locale/es-mx/default/wp-plugins/customize-posts):

> This plugin is not properly prepared for localization.

<img width="982" alt="projects_translated_to_spanish__mexico____glotpress_ _wordpress" src="https://cloud.githubusercontent.com/assets/134745/17464262/a6608df6-5c8f-11e6-91ec-2ef8cf3deb0a.png">

I thought that the `Text Domain` plugin meta could be empty since it is now assumed to be the slug, I thought, but I added it in https://github.com/xwp/wp-customize-posts/commit/421da210a44a1b6defd7e70055d42475bed5ab9d to try to fix the issue on translate.wordpress.org. However, that didn't fix it in 0.7.0. I also thought that `Domain Path` was optional, but maybe it isn't. 

Anyone have any specifics for what is missing?