### PR TITLE
Issue #132 : Allow filtering to disable 'posts' component.

### DIFF
--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -165,6 +165,10 @@ class Customize_Posts_Plugin {
 	 */
 	function load_support_classes( $wp_customize ) {
 
+		if ( ! isset( $wp_customize->posts ) ) {
+			return;
+		}
+
 		// Theme & Plugin Support.
 		require_once dirname( __FILE__ ) . '/class-customize-posts-support.php';
 		require_once dirname( __FILE__ ) . '/class-customize-posts-plugin-support.php';

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -66,6 +66,7 @@ class Customize_Posts_Plugin {
 		add_action( 'wp_default_styles', array( $this, 'register_styles' ), 11 );
 		add_action( 'init', array( $this, 'register_customize_draft' ) );
 		add_filter( 'user_has_cap', array( $this, 'grant_customize_capability' ), 10, 3 );
+		add_filter( 'customize_loaded_components', array( $this, 'add_posts_to_customize_loaded_components' ), 0, 2 );
 		add_filter( 'customize_loaded_components', array( $this, 'filter_customize_loaded_components' ), 100, 2 );
 		add_action( 'customize_register', array( $this, 'load_support_classes' ) );
 
@@ -121,9 +122,26 @@ class Customize_Posts_Plugin {
 	}
 
 	/**
+	 * Add 'posts' to array of components that Customizer loads.
+	 *
+	 * A later filter may remove this, to avoid loading this component.
+	 *
+	 * @param array                $components   Components.
+	 * @param WP_Customize_Manager $wp_customize Manager.
+	 * @return array Components.
+	 */
+	function add_posts_to_customize_loaded_components( $components, $wp_customize ) {
+		array_push( $components, 'posts' );
+
+		return $components;
+	}
+
+	/**
 	 * Bootstrap.
 	 *
 	 * This will be part of the WP_Customize_Manager::__construct() or another such class constructor in #coremerge.
+	 * Only instantiate WP_Customize_Posts if 'posts' is present in $components.
+	 * This will allow disabling 'posts' through filtering.
 	 *
 	 * @param array                $components   Components.
 	 * @param WP_Customize_Manager $wp_customize Manager.
@@ -131,7 +149,9 @@ class Customize_Posts_Plugin {
 	 */
 	function filter_customize_loaded_components( $components, $wp_customize ) {
 		require_once dirname( __FILE__ ) . '/class-wp-customize-posts.php';
-		$wp_customize->posts = new WP_Customize_Posts( $wp_customize );
+		if ( in_array( 'posts', $components ) ) {
+			$wp_customize->posts = new WP_Customize_Posts( $wp_customize );
+		}
 
 		return $components;
 	}

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -126,7 +126,7 @@ class Customize_Posts_Plugin {
 	 *
 	 * A later filter may remove this, to avoid loading this component.
 	 *
-	 * @param array                $components   Components.
+	 * @param array $components Components.
 	 * @return array Components.
 	 */
 	function add_posts_to_customize_loaded_components( $components ) {

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -66,7 +66,7 @@ class Customize_Posts_Plugin {
 		add_action( 'wp_default_styles', array( $this, 'register_styles' ), 11 );
 		add_action( 'init', array( $this, 'register_customize_draft' ) );
 		add_filter( 'user_has_cap', array( $this, 'grant_customize_capability' ), 10, 3 );
-		add_filter( 'customize_loaded_components', array( $this, 'add_posts_to_customize_loaded_components' ), 0, 2 );
+		add_filter( 'customize_loaded_components', array( $this, 'add_posts_to_customize_loaded_components' ), 0, 1 );
 		add_filter( 'customize_loaded_components', array( $this, 'filter_customize_loaded_components' ), 100, 2 );
 		add_action( 'customize_register', array( $this, 'load_support_classes' ) );
 
@@ -127,10 +127,9 @@ class Customize_Posts_Plugin {
 	 * A later filter may remove this, to avoid loading this component.
 	 *
 	 * @param array                $components   Components.
-	 * @param WP_Customize_Manager $wp_customize Manager.
 	 * @return array Components.
 	 */
-	function add_posts_to_customize_loaded_components( $components, $wp_customize ) {
+	function add_posts_to_customize_loaded_components( $components ) {
 		array_push( $components, 'posts' );
 
 		return $components;
@@ -149,7 +148,7 @@ class Customize_Posts_Plugin {
 	 */
 	function filter_customize_loaded_components( $components, $wp_customize ) {
 		require_once dirname( __FILE__ ) . '/class-wp-customize-posts.php';
-		if ( in_array( 'posts', $components ) ) {
+		if ( in_array( 'posts', $components, true ) ) {
 			$wp_customize->posts = new WP_Customize_Posts( $wp_customize );
 		}
 

--- a/php/class-wp-customize-featured-image-controller.php
+++ b/php/class-wp-customize-featured-image-controller.php
@@ -281,7 +281,7 @@ class WP_Customize_Featured_Image_Controller extends WP_Customize_Postmeta_Contr
 	 * @return false|array Partial args or false if not a match.
 	 */
 	public function filter_customize_dynamic_partial_args( $partial_args, $partial_id ) {
-		if ( preg_match( WP_Customize_Postmeta_Setting::SETTING_ID_PATTERN, $partial_id, $matches ) && $matches['meta_key'] === $this->meta_key ) {
+		if ( class_exists( 'WP_Customize_Postmeta_Setting' ) && preg_match( WP_Customize_Postmeta_Setting::SETTING_ID_PATTERN, $partial_id, $matches ) && $matches['meta_key'] === $this->meta_key ) {
 			if ( false === $partial_args ) {
 				$partial_args = array();
 			}


### PR DESCRIPTION
@westonruter, 
Could you please review this pull request for Issue #132?

The new filter `add_posts_to_customize_loaded_components` adds `'posts'` to the array of components in the Customizer.
And `WP_Customize_Posts` is only instantiated if `'posts'` is still present.
So a later filter may remove `'posts'`, to disable it.

One issue I noticed is that if a filter does remove `'posts'`, it causes a fatal error:

```Notice: Undefined property: WP_Customize_Manager::$posts in /srv/www/wordpress-develop/src/wp-content/plugins/wp-customize-posts/php/class-customize-posts-plugin.php on line 179
Fatal error: Call to a member function add_support() on a non-object in /srv/www/wordpress-develop/src/wp-content/plugins/wp-customize-posts/php/class-customize-posts-plugin.php on line 179```

Removing the action [on line #71](https://github.com/xwp/wp-customize-posts/blob/feature/allow-removing-posts-component/php/class-customize-posts-plugin.php#L71) removed that error, but there was another fatal error.

I could have missed something here.

Fixes #132.