### PR TITLE
Issue #207 : Rename 'Save & Publish' button to 'Save'.

### DIFF
--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -588,6 +588,9 @@
 		api.previewer.bind( 'focus-control', component.focusControl );
 
 		component.ensureAutofocusConstructPosts();
+
+		// Change 'Save & Publish' button value to 'Save'
+		api.l10n.save = 'Save';
 	} );
 
 })( wp.customize, jQuery );


### PR DESCRIPTION
**Request For Review**

Hi @westonruter, 
Could you please see this pull request, which sets a new name for the `'Save & Publish'` button? It's `'Save'` for the moment, pending whatever name you'd like to give it.

As you [suggested in #35547](https://core.trac.wordpress.org/ticket/35547#trac-change-1-1453324602035002), this overwrites `api.l10n.save`. When the Customizer initially loads, the value (text) of the button is `'Save & Publish'`. In about 500 milliseconds, it replaces this with `'Saved'`.

As you know, this `'Save & Publish'` text is originally produced with PHP in [customize.php#L117](https://core.trac.wordpress.org/browser/trunk/src/wp-admin/customize.php#L117). So if we'd like to prevent it from appearing at all, it would have to be overwritten with JavaScript earlier than it’s already overwritten, which I think is in [customize-controls.js#L3908](https://core.trac.wordpress.org/browser/trunk/src/wp-admin/js/customize-controls.js#L3908). 
