### PR TITLE
[WP4.7] Eliminate active validate overrides for WP 4.7-alpha-38464

### DIFF
--- a/js/customize-featured-image.js
+++ b/js/customize-featured-image.js
@@ -123,11 +123,6 @@ var CustomizeFeaturedImage = (function( api ) {
 			} );
 		};
 
-		control.active.set( true );
-		control.active.validate = function validateForcingTrue() {
-			return true;
-		};
-
 		// Register.
 		api.control.add( control.id, control );
 

--- a/js/customize-page-template.js
+++ b/js/customize-page-template.js
@@ -50,7 +50,7 @@ var CustomizePageTemplate = (function( api ) {
 	 * @returns {wp.customize.Control|null} The control.
 	 */
 	component.addControl = function( section ) {
-		var supports, control, controlId, settingId, isActiveCallback;
+		var supports, control, controlId, settingId;
 		supports = api.Posts.data.postTypes[ section.params.post_type ].supports;
 
 		if ( ! supports['page-attributes'] || 'page' !== section.params.post_type ) {
@@ -100,12 +100,11 @@ var CustomizePageTemplate = (function( api ) {
 		 *
 		 * @returns {boolean} Is active.
 		 */
-		isActiveCallback = function() {
+		control.active.setter( function activeSetter( active ) {
 			var defaultSize = 1;
-			return _.size( control.params.choices ) > defaultSize;
-		};
-		control.active.set( isActiveCallback() );
-		control.active.validate = isActiveCallback;
+			return active && _.size( control.params.choices ) > defaultSize;
+		} );
+		control.active.set( true );
 
 		// Register.
 		api.control.add( control.id, control );

--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -361,11 +361,6 @@
 				}
 			} );
 
-			// Override preview trying to de-activate control not present in preview context. See WP Trac #37270.
-			control.active.validate = function() {
-				return true;
-			};
-
 			// Register.
 			section.postFieldControls.post_title = control;
 			api.control.add( control.id, control );
@@ -419,11 +414,6 @@
 				setting.bind( setPlaceholder );
 			} );
 
-			// Override preview trying to de-activate control not present in preview context. See WP Trac #37270.
-			control.active.validate = function() {
-				return true;
-			};
-
 			// Register.
 			section.postFieldControls.post_name = control;
 			api.control.add( control.id, control );
@@ -454,11 +444,6 @@
 					}
 				}
 			} );
-
-			// Override preview trying to de-activate control not present in preview context. See WP Trac #37270.
-			control.active.validate = function() {
-				return true;
-			};
 
 			// Register.
 			section.postFieldControls.post_status = control;
@@ -492,11 +477,6 @@
 				}
 			} );
 
-			// Override preview trying to de-activate control not present in preview context. See WP Trac #37270.
-			control.active.validate = function() {
-				return true;
-			};
-
 			// Register.
 			section.postFieldControls.post_date = control;
 			api.control.add( control.id, control );
@@ -527,11 +507,6 @@
 					}
 				}
 			} );
-
-			// Override preview trying to de-activate control not present in preview context. See WP Trac #37270.
-			control.active.validate = function() {
-				return true;
-			};
 
 			// Register.
 			section.postFieldControls.post_content = control;
@@ -566,11 +541,6 @@
 				}
 			} );
 
-			// Override preview trying to de-activate control not present in preview context. See WP Trac #37270.
-			control.active.validate = function() {
-				return true;
-			};
-
 			// Register.
 			section.postFieldControls.post_excerpt = control;
 			api.control.add( control.id, control );
@@ -602,11 +572,6 @@
 					post_type_supports: postTypeObj.supports
 				}
 			} );
-
-			// Override preview trying to de-activate control not present in preview context. See WP Trac #37270.
-			control.active.validate = function() {
-				return true;
-			};
 
 			// Register.
 			section.postFieldControls.post_discussion_fields = control;
@@ -649,11 +614,6 @@
 				data = previousValidate.call( this, data );
 				data.post_author = parseInt( data.post_author, 10 );
 				return data;
-			};
-
-			// Override preview trying to de-activate control not present in preview context. See WP Trac #37270.
-			control.active.validate = function() {
-				return true;
 			};
 
 			// Register.


### PR DESCRIPTION
_This PR cannot be merged until WordPress 4.7 is the minimum-supported version._

See https://core.trac.wordpress.org/changeset/38464
See https://core.trac.wordpress.org/ticket/37270

Fixes #157 
