### PR TITLE
Ensure that preview urls are used as permalinks for customized posts

### DIFF
--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -150,6 +150,10 @@ class Customize_Posts_Plugin {
 
 		foreach ( array( 'theme', 'plugin' ) as $type ) {
 			foreach ( glob( dirname( __FILE__ ) . '/' . $type . '-support/class-*.php' ) as $file_path ) {
+				if ( 0 !== validate_file( $file_path ) ) {
+					continue;
+				}
+
 				require_once $file_path;
 
 				$class_name = str_replace( '-', '_', preg_replace( '/^class-(.+)\.php$/', '$1', basename( $file_path ) ) );

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -1176,7 +1176,7 @@ final class WP_Customize_Posts {
 		$query_args['paged'] = max( 1, $query_args['paged'] );
 
 		if ( ! empty( $_POST['s'] ) ) {
-			$query_args['s'] = wp_unslash( $_POST['s'] );
+			$query_args['s'] = sanitize_text_field( wp_unslash( $_POST['s'] ) );
 		}
 
 		$query_args['post_status'] = get_post_stati( array( 'protected' => true ) );

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -406,20 +406,6 @@ final class WP_Customize_Posts {
 	}
 
 	/**
-	 * When loading the customizer from a post, get the post.
-	 *
-	 * @return WP_Post|null
-	 */
-	public function get_previewed_post() {
-		$post_id = url_to_postid( $this->manager->get_preview_url() );
-		if ( 0 === $post_id ) {
-			return null;
-		}
-		$post = get_post( $post_id );
-		return $post;
-	}
-
-	/**
 	 * Get the post status choices array.
 	 *
 	 * @return array

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -847,7 +847,10 @@ final class WP_Customize_Posts {
 	 * @access public
 	 */
 	public function preview_customize_draft_post_ids() {
-		if ( isset( $_REQUEST['preview'] ) ) { // @todo Why not look at $wp_query->is_preview()?
+
+		// Note that is_preview() cannot be used because this is called at after_setup_theme before WP_Query is initialized.
+		$is_preview = isset( $_GET['preview'] );
+		if ( $is_preview ) {
 			$this->customize_draft_post_ids = array();
 			foreach ( $this->manager->unsanitized_post_values() as $id => $post_data ) {
 				if ( ! preg_match( WP_Customize_Post_Setting::SETTING_ID_PATTERN, $id, $matches ) ) {

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -899,7 +899,8 @@ final class WP_Customize_Posts {
 	 * @return string
 	 */
 	public function post_link_draft( $permalink, $post ) {
-		if ( is_customize_preview() && ! $this->suppress_post_link_filters ) {
+		$post_setting_id = WP_Customize_Post_Setting::get_post_setting_id( get_post( $post ) );
+		if ( ( is_customize_preview() && ! $this->suppress_post_link_filters ) || array_key_exists( $post_setting_id, $this->manager->unsanitized_post_values() ) ) {
 			$permalink = Edit_Post_Preview::get_preview_post_link( get_post( $post ) );
 		}
 		return $permalink;

--- a/tests/php/test-class-wp-customize-posts-preview.php
+++ b/tests/php/test-class-wp-customize-posts-preview.php
@@ -372,7 +372,9 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 			'post_title' => 'Testing Page Draft',
 			'post_status' => 'publish',
 		);
-		$_POST['customized'] = wp_slash( wp_json_encode( $data ) );
+		foreach ( $data as $id => $value ) {
+			$this->posts_component->manager->set_post_value( $id, $value );
+		}
 
 		$query = new WP_Query( array( 'post_type' => 'post' ) );
 		$this->assertEquals( array( $post->ID ), $this->posts_component->preview->get_previewed_posts_for_query( $query ) );

--- a/tests/php/test-class-wp-customize-posts.php
+++ b/tests/php/test-class-wp-customize-posts.php
@@ -75,7 +75,6 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 		unset( $_POST['customized'] );
 		unset( $GLOBALS['wp_customize'] );
 		unset( $GLOBALS['wp_scripts'] );
-		unset( $_REQUEST['preview'] );
 		unset( $_REQUEST['customize_snapshot_uuid'] );
 		parent::tearDown();
 	}
@@ -519,11 +518,10 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 		$this->posts->preview_customize_draft_post_ids();
 		$this->assertEmpty( $this->posts->customize_draft_post_ids );
 
-		$_REQUEST['preview'] = 'true';
-		$this->posts->preview_customize_draft_post_ids();
-		$this->assertEmpty( $this->posts->customize_draft_post_ids );
-
 		$post_id = $this->factory()->post->create();
+		$this->go_to( home_url( sprintf( '/?preview=true&p=%d', $post_id ) ) );
+		$this->assertTrue( isset( $_GET['preview'] ) );
+
 		$setting_id = WP_Customize_Post_Setting::get_post_setting_id( get_post( $post_id ) );
 		$settings = $this->posts->manager->add_dynamic_settings( array( $setting_id ) );
 		$setting = array_shift( $settings );
@@ -589,13 +587,14 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 		$GLOBALS['current_user'] = null;
 
 		$this->go_to( home_url( sprintf( '?%s=%d&preview=true', 'page' === $post_type ? 'page_id' : 'p', $post->ID ) ) );
-		$_REQUEST['preview'] = 'true';
+		$this->assertTrue( isset( $_GET['preview'] ) );
 		$this->posts->preview_customize_draft_post_ids();
 		$GLOBALS['wp_query']->query( $GLOBALS['wp']->query_vars );
 
 		$this->assertTrue( $GLOBALS['wp_query']->is_preview );
 		$this->assertEquals( 'true', $GLOBALS['wp_query']->query_vars['preview'] );
 		$this->assertEquals( $post->ID, $GLOBALS['wp_query']->query_vars['p'] );
+		$this->assertArrayHasKey( 'post_status', $GLOBALS['wp_query']->query_vars );
 		$this->assertEquals( 'customize-draft', $GLOBALS['wp_query']->query_vars['post_status'] );
 	}
 

--- a/tests/php/test-class-wp-customize-posts.php
+++ b/tests/php/test-class-wp-customize-posts.php
@@ -290,31 +290,6 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the previewed post is returned.
-	 *
-	 * @see WP_Customize_Posts::get_previewed_post()
-	 */
-	public function test_get_previewed_post() {
-		$this->wp_customize->set_preview_url( get_permalink( $this->post_id ) );
-		$posts = new WP_Customize_Posts( $this->wp_customize );
-		$this->do_customize_boot_actions();
-		$post = $posts->get_previewed_post();
-		$this->assertEquals( $this->post_id, $post->ID );
-	}
-
-	/**
-	 * Test that the previewed post is null.
-	 *
-	 * @see WP_Customize_Posts::get_previewed_post()
-	 */
-	public function test_get_previewed_post_is_null() {
-		$posts = new WP_Customize_Posts( $this->wp_customize );
-		$this->do_customize_boot_actions();
-		$post = $posts->get_previewed_post();
-		$this->assertNull( $post );
-	}
-
-	/**
 	 * Tests get_post_status_choices().
 	 *
 	 * @covers WP_Customize_Posts::get_post_status_choices()


### PR DESCRIPTION
This fixes an issue in snapshots frontend preview where auto-draft posts previewed as published would get erroneously redirected from the preview URL to instead have a URL like `/-0001/11/30/` since the date is `0000-00-00` and the post_name is empty. This URL would then redirect to the homepage.

This also ensures that WordPress will be able to locate the customized post since the `post_name` may have been changed.

This PR also adds (for good measure) a `validate_file()` to the results of a `glob()`, and adds `sanitize_text_field()` for the input of post searching.