### PR TITLE
Make sure that customized posts appear on the first page of results (i.e. homepage)

### DIFF
--- a/tests/php/test-class-wp-customize-posts-preview.php
+++ b/tests/php/test-class-wp-customize-posts-preview.php
@@ -329,6 +329,15 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test amend_first_paged_query_posts_with_customized_posts.
+	 *
+	 * @covers WP_Customize_Posts_Preview::amend_first_paged_query_posts_with_customized_posts()
+	 */
+	public function test_amend_first_paged_query_posts_with_customized_posts() {
+		$this->markTestIncomplete();
+	}
+
+	/**
 	 * Test filter_the_posts_to_tally_orderby_keys().
 	 *
 	 * @covers WP_Customize_Posts_Preview::filter_the_posts_to_tally_orderby_keys()


### PR DESCRIPTION
This is particularly useful when there are more than {page_per_posts} of posts on the site. If you add a new post in the customizer and then try navigating to the post index in the preview, the newly added post will not appear on the first page, even though it may have `post_date` that would put it there (even `0000-00-00` as `current_time()`, which is also why it won't appear at front of the list since it has the lowest date and so appears on last page).

The reason for needing this logic is because `WP_Query` is not fully previewable yet. See https://github.com/xwp/wp-customize-posts/issues/246