### PR TITLE
Use non-minified scripts and styles if plugin installed via git (submodule)

### DIFF
--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -177,7 +177,8 @@ class Customize_Posts_Plugin {
 	 * @param WP_Scripts $wp_scripts Scripts.
 	 */
 	public function register_scripts( WP_Scripts $wp_scripts ) {
-		$suffix = ( SCRIPT_DEBUG ? '' : '.min' ) . '.js';
+		$is_git_repo = file_exists( dirname( dirname( __FILE__ ) ) . '/.git' );
+		$suffix = ( SCRIPT_DEBUG || $is_git_repo ? '' : '.min' ) . '.js';
 
 		$handle = 'select2';
 		if ( ! $wp_scripts->query( $handle, 'registered' ) ) {
@@ -320,7 +321,8 @@ class Customize_Posts_Plugin {
 	 * @param WP_Styles $wp_styles Styles.
 	 */
 	public function register_styles( WP_Styles $wp_styles ) {
-		$suffix = ( SCRIPT_DEBUG ? '' : '.min' ) . '.css';
+		$is_git_repo = file_exists( dirname( dirname( __FILE__ ) ) . '/.git' );
+		$suffix = ( SCRIPT_DEBUG || $is_git_repo ? '' : '.min' ) . '.css';
 
 		$handle = 'select2';
 		if ( ! $wp_styles->query( $handle, 'registered' ) ) {


### PR DESCRIPTION
This should largely eliminate the need for #133 and it will fix a contributor's first hurdle when they clone the plugin from GitHub, activate it, and find it to be broken.