### PR TITLE
Add rudimentary number-based menu_order field

### DIFF
--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -400,7 +400,7 @@
 			control = new api.controlConstructor.dynamic( section.id + '[post_name]', {
 				params: {
 					section: section.id,
-					priority: 15,
+					priority: 20,
 					label: postTypeObj.labels.slug_field ? postTypeObj.labels.slug_field : api.Posts.data.l10n.fieldSlugLabel,
 					active: true,
 					settings: {
@@ -450,7 +450,7 @@
 			control = new api.controlConstructor.post_status( section.id + '[post_status]', {
 				params: {
 					section: section.id,
-					priority: 20,
+					priority: 30,
 					label: postTypeObj.labels.status_field ? postTypeObj.labels.status_field : api.Posts.data.l10n.fieldStatusLabel,
 					settings: {
 						'default': setting.id
@@ -475,6 +475,118 @@
 		},
 
 		/**
+		 * Add post date control.
+		 *
+		 * @returns {wp.customize.Control} Added control.
+		 */
+		addDateControl: function() {
+			var section = this, control, setting = api( section.id ), postTypeObj;
+			postTypeObj = api.Posts.data.postTypes[ section.params.post_type ];
+
+			control = new api.controlConstructor.post_date( section.id + '[post_date]', {
+				params: {
+					section: section.id,
+					priority: 40,
+					label: postTypeObj.labels.date_field ? postTypeObj.labels.date_field : api.Posts.data.l10n.fieldDateLabel,
+					description: api.Posts.data.l10n.fieldDateDescription,
+					settings: {
+						'default': setting.id
+					}
+				}
+			} );
+
+			// Override preview trying to de-activate control not present in preview context. See WP Trac #37270.
+			control.active.validate = function() {
+				return true;
+			};
+
+			// Register.
+			section.postFieldControls.post_date = control;
+			api.control.add( control.id, control );
+
+			if ( control.notifications ) {
+				control.notifications.add = section.addPostFieldControlNotification;
+				control.notifications.setting_property = control.params.setting_property;
+			}
+			return control;
+		},
+
+		/**
+		 * Add post content control.
+		 *
+		 * @returns {wp.customize.Control} Added control.
+		 */
+		addContentControl: function() {
+			var section = this, control, setting = api( section.id ), postTypeObj;
+			postTypeObj = api.Posts.data.postTypes[ section.params.post_type ];
+
+			control = new api.controlConstructor.post_editor( section.id + '[post_content]', {
+				params: {
+					section: section.id,
+					priority: 50,
+					label: postTypeObj.labels.content_field ? postTypeObj.labels.content_field : api.Posts.data.l10n.fieldContentLabel,
+					setting_property: 'post_content',
+					settings: {
+						'default': setting.id
+					}
+				}
+			} );
+
+			// Override preview trying to de-activate control not present in preview context. See WP Trac #37270.
+			control.active.validate = function() {
+				return true;
+			};
+
+			// Register.
+			section.postFieldControls.post_content = control;
+			api.control.add( control.id, control );
+
+			if ( control.notifications ) {
+				control.notifications.add = section.addPostFieldControlNotification;
+				control.notifications.setting_property = control.params.setting_property;
+			}
+			return control;
+		},
+
+		/**
+		 * Add post excerpt control.
+		 *
+		 * @returns {wp.customize.Control} Added control.
+		 */
+		addExcerptControl: function() {
+			var section = this, control, setting = api( section.id ), postTypeObj;
+			postTypeObj = api.Posts.data.postTypes[ section.params.post_type ];
+			control = new api.controlConstructor.dynamic( section.id + '[post_excerpt]', {
+				params: {
+					section: section.id,
+					priority: 60,
+					label: postTypeObj.labels.excerpt_field ? postTypeObj.labels.excerpt_field : api.Posts.data.l10n.fieldExcerptLabel,
+					active: true,
+					settings: {
+						'default': setting.id
+					},
+					field_type: 'textarea',
+					setting_property: 'post_excerpt'
+				}
+			} );
+
+			// Override preview trying to de-activate control not present in preview context. See WP Trac #37270.
+			control.active.validate = function() {
+				return true;
+			};
+
+			// Register.
+			section.postFieldControls.post_excerpt = control;
+			api.control.add( control.id, control );
+
+			if ( control.notifications ) {
+				control.notifications.add = section.addPostFieldControlNotification;
+				control.notifications.setting_property = control.params.setting_property;
+			}
+			return control;
+		},
+
+		/**
 		 * Add parent control.
 		 *
 		 * @returns {wp.customize.Control} Added control.
@@ -486,7 +598,7 @@
 			controlId = section.id + '[post_parent]';
 			params = {
 				section: section.id,
-				priority: 20,
+				priority: 70,
 				label: postTypeObj.labels.parent_item_colon ? postTypeObj.labels.parent_item_colon.replace( /:$/, '' ) : api.Posts.data.l10n.fieldParentLabel,
 				active: true,
 				settings: {
@@ -544,117 +656,6 @@
 		},
 
 		/**
-		 * Add post date control.
-		 *
-		 * @returns {wp.customize.Control} Added control.
-		 */
-		addDateControl: function() {
-			var section = this, control, setting = api( section.id ), postTypeObj;
-			postTypeObj = api.Posts.data.postTypes[ section.params.post_type ];
-
-			control = new api.controlConstructor.post_date( section.id + '[post_date]', {
-				params: {
-					section: section.id,
-					priority: 21,
-					label: postTypeObj.labels.date_field ? postTypeObj.labels.date_field : api.Posts.data.l10n.fieldDateLabel,
-					description: api.Posts.data.l10n.fieldDateDescription,
-					settings: {
-						'default': setting.id
-					}
-				}
-			} );
-
-			// Override preview trying to de-activate control not present in preview context. See WP Trac #37270.
-			control.active.validate = function() {
-				return true;
-			};
-
-			// Register.
-			section.postFieldControls.post_date = control;
-			api.control.add( control.id, control );
-
-			if ( control.notifications ) {
-				control.notifications.add = section.addPostFieldControlNotification;
-				control.notifications.setting_property = control.params.setting_property;
-			}
-			return control;
-		},
-
-		/**
-		 * Add post content control.
-		 *
-		 * @returns {wp.customize.Control} Added control.
-		 */
-		addContentControl: function() {
-			var section = this, control, setting = api( section.id ), postTypeObj;
-			postTypeObj = api.Posts.data.postTypes[ section.params.post_type ];
-
-			control = new api.controlConstructor.post_editor( section.id + '[post_content]', {
-				params: {
-					section: section.id,
-					label: postTypeObj.labels.content_field ? postTypeObj.labels.content_field : api.Posts.data.l10n.fieldContentLabel,
-					setting_property: 'post_content',
-					settings: {
-						'default': setting.id
-					}
-				}
-			} );
-
-			// Override preview trying to de-activate control not present in preview context. See WP Trac #37270.
-			control.active.validate = function() {
-				return true;
-			};
-
-			// Register.
-			section.postFieldControls.post_content = control;
-			api.control.add( control.id, control );
-
-			if ( control.notifications ) {
-				control.notifications.add = section.addPostFieldControlNotification;
-				control.notifications.setting_property = control.params.setting_property;
-			}
-			return control;
-		},
-
-		/**
-		 * Add post excerpt control.
-		 *
-		 * @returns {wp.customize.Control} Added control.
-		 */
-		addExcerptControl: function() {
-			var section = this, control, setting = api( section.id ), postTypeObj;
-			postTypeObj = api.Posts.data.postTypes[ section.params.post_type ];
-			control = new api.controlConstructor.dynamic( section.id + '[post_excerpt]', {
-				params: {
-					section: section.id,
-					priority: 30,
-					label: postTypeObj.labels.excerpt_field ? postTypeObj.labels.excerpt_field : api.Posts.data.l10n.fieldExcerptLabel,
-					active: true,
-					settings: {
-						'default': setting.id
-					},
-					field_type: 'textarea',
-					setting_property: 'post_excerpt'
-				}
-			} );
-
-			// Override preview trying to de-activate control not present in preview context. See WP Trac #37270.
-			control.active.validate = function() {
-				return true;
-			};
-
-			// Register.
-			section.postFieldControls.post_excerpt = control;
-			api.control.add( control.id, control );
-
-			if ( control.notifications ) {
-				control.notifications.add = section.addPostFieldControlNotification;
-				control.notifications.setting_property = control.params.setting_property;
-			}
-			return control;
-		},
-
-		/**
 		 * Add discussion fields (comments and ping status fields) control.
 		 *
 		 * @returns {wp.customize.Control} Added control.
@@ -665,7 +666,7 @@
 			control = new api.controlConstructor.post_discussion_fields( section.id + '[discussion_fields]', {
 				params: {
 					section: section.id,
-					priority: 60,
+					priority: 80,
 					label: postTypeObj.labels.discussion_field ? postTypeObj.labels.discussion_field : api.Posts.data.l10n.fieldDiscusionLabel,
 					active: true,
 					settings: {
@@ -702,7 +703,7 @@
 			control = new api.controlConstructor.dynamic( section.id + '[post_author]', {
 				params: {
 					section: section.id,
-					priority: 70,
+					priority: 90,
 					label: postTypeObj.labels.author_field ? postTypeObj.labels.author_field : api.Posts.data.l10n.fieldAuthorLabel,
 					active: true,
 					settings: {

--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -1071,6 +1071,9 @@ final class WP_Customize_Posts_Preview {
 			'post_parent' => array(
 				'fallback_refresh' => true,
 			),
+			'menu_order' => array(
+				'fallback_refresh' => true,
+			),
 			'post_date' => array(
 				'selector' => 'time.entry-date',
 				'fallback_refresh' => false,

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -728,6 +728,7 @@ final class WP_Customize_Posts {
 				'fieldDiscussionLabel' => __( 'Discussion', 'customize-posts' ),
 				'fieldAuthorLabel' => __( 'Author', 'customize-posts' ),
 				'fieldParentLabel' => __( 'Parent', 'customize-posts' ),
+				'fieldOrderLabel' => __( 'Order', 'customize-posts' ),
 				'noTitle' => __( '(no title)', 'customize-posts' ),
 				'theirChange' => __( 'Their change: %s', 'customize-posts' ),
 				'openEditor' => __( 'Open Editor', 'customize-posts' ), // @todo Move this into editor control?


### PR DESCRIPTION
A better drag-and-drop UI needs to be developed for this (in core as well). For now, something is better than nothing. See #32.

Note that this introduces a new post-type support called “`ordering`” which can be used to enable _just_ the order field since the `page-attributes` field enables both the `post_parent` and `menu_order` controls.

Fixes #84.