### PR TITLE
Sync page changes to Static Front Page section controls; prevent same page from being used as both page for posts and page on front

### DIFF
--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -915,11 +915,13 @@
 		/**
 		 * Sync page changes to all dropdown-pages controls and to the page_on_front/page_for_posts settings.
 		 *
+		 * @see wp.customize.Posts.preventStaticFrontPageCollision()
+		 * @see wp.customize.Posts.PostSection.removeFromDropdownPagesControls()
 		 * @this {wp.customize.Section}
 		 * @param {Object} newPostData  Updated page data.
 		 * @returns {void}
 		 */
-		syncPageData: function( newPostData ) {
+		syncPageData: function syncPageData( newPostData ) {
 			var section = this;
 
 			// Make sure the page_for_posts and page_on_front settings get unset if the selected page is trashed.
@@ -963,7 +965,7 @@
 					pageOption.text( optionText );
 				}
 
-				// @todo In the case of page_on_front and page_for_posts, this should only be done if it wouldn't mean that they can be set to the same. See https://github.com/xwp/wp-customize-object-selector/pull/22
+				// Note that the option may or may not also be hidden. The visibility is tied a collision-prevention state.
 				pageOption.prop( 'disabled', isTrashed );
 			});
 		},

--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -423,7 +423,7 @@
 				delete component.fetchedPosts[ section.params.post_id ];
 
 				if ( 'page' === section.params.post_type ) {
-					section.purgeStaticPageDropDown( section.params.post_id );
+					section.removeFromDropdownPagesControls();
 				}
 			}
 		} );

--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -539,6 +539,83 @@
 	};
 
 	/**
+	 * Prevent the page on front and the page for posts from being set to be the same.
+	 *
+	 * Note that when the static front page is set to a given page, this same page will
+	 * be hidden from the page on front dropdown, and vice versa. In contrast, when
+	 * a page is trashed it will be *disabled* in the dropdowns. So there are two states
+	 * that effect whether or not an option should be selected. So it is taking advantage
+	 * of the `disabled` and `hidden` to correspond to these two separate states so that
+	 * they don't overwrite each other and accidentally allow an option to be selected.
+	 *
+	 * @see wp.customize.Posts.PostSection.syncPageData()
+	 * @see wp.customize.Posts.PostSection.removeFromDropdownPagesControls()
+	 *
+	 * See also https://github.com/xwp/wp-customize-object-selector/blob/develop/js/customize-object-selector-static-front-page.js
+	 *
+	 * @returns {void}
+	 */
+	component.preventStaticFrontPageCollision = function preventStaticFrontPageCollision() {
+
+		api( 'page_for_posts', 'page_on_front', function( pageForPostsSetting, pageOnFrontSetting ) {
+
+			// Prevent the settings from being set to be the same.
+			pageForPostsSetting.bind( function onChangePageForPosts( pageId ) {
+				if ( parseInt( pageId, 10 ) === parseInt( pageOnFrontSetting.get(), 10 ) ) {
+					pageOnFrontSetting.set( 0 );
+				}
+			} );
+			pageOnFrontSetting.bind( function onChangePageOnFront( pageId ) {
+				if ( parseInt( pageId, 10 ) === parseInt( pageForPostsSetting.get(), 10 ) ) {
+					pageForPostsSetting.set( 0 );
+				}
+			} );
+
+			// Hide the page options to prevent selecting the same. Note that trashed posts get disabled
+			api.control( 'page_for_posts', 'page_on_front', function( pageForPostsControl, pageOnFrontControl ) {
+				var onChangePageForPostsControl, onChangePageOnFrontControl;
+
+				if ( 'dropdown-pages' !== pageForPostsControl.params.type || 'dropdown-pages' !== pageOnFrontControl.params.type ) {
+					return;
+				}
+
+				// Note that the options below may or may not also be disabled. The disabled is tied a the trashed state of the pages.
+				onChangePageForPostsControl = function( newPageForPosts, oldPageForPosts ) {
+					var oldPageForPostsId, newPageForPostsId;
+					oldPageForPostsId = parseInt( oldPageForPosts, 10 );
+					newPageForPostsId = parseInt( newPageForPosts, 10 );
+					if ( 0 !== oldPageForPostsId ) {
+						pageOnFrontControl.container.find( 'option[value="' + String( oldPageForPostsId ) + '"]' ).show();
+					}
+					if ( 0 !== newPageForPostsId ) {
+						pageOnFrontControl.container.find( 'option[value="' + String( newPageForPostsId ) + '"]' ).hide();
+					}
+				};
+
+				onChangePageOnFrontControl = function( newPageOnFront, oldPageOnFront ) {
+					var oldPageOnFrontId, newPageOnFrontId;
+					oldPageOnFrontId = parseInt( oldPageOnFront, 10 );
+					newPageOnFrontId = parseInt( newPageOnFront, 10 );
+					if ( 0 !== oldPageOnFrontId ) {
+						pageForPostsControl.container.find( 'option[value="' + String( oldPageOnFrontId ) + '"]' ).show();
+					}
+					if ( 0 !== newPageOnFrontId ) {
+						pageForPostsControl.container.find( 'option[value="' + String( newPageOnFrontId ) + '"]' ).hide();
+					}
+				};
+
+				$.when( pageForPostsControl.deferred.embedded, pageOnFrontControl.deferred.embedded ).done( function() {
+					pageForPostsSetting.bind( onChangePageForPostsControl );
+					onChangePageForPostsControl( pageForPostsSetting.get() );
+					pageOnFrontSetting.bind( onChangePageOnFrontControl );
+					onChangePageOnFrontControl( pageOnFrontSetting.get() );
+				} );
+			} );
+		} );
+
+	};
+
+	/**
 	 * Ensure that the post associated with an autofocused section or control is loaded.
 	 *
 	 * @returns {int[]} Post IDs autofocused.
@@ -587,13 +664,10 @@
 			if ( data.saved_post_setting_values ) {
 				component.updateSettingsQuietly( data.saved_post_setting_values );
 			}
-
 			component.purgeTrash();
 		} );
 
-		/**
-		 * Ensure a post is added to the Customizer and focus on its section when an edit post link is clicked in preview.
-		 */
+		// Ensure a post is added to the Customizer and focus on its section when an edit post link is clicked in preview.
 		api.previewer.bind( 'edit-post', function( postId ) {
 			var ensuredPromise = api.Posts.ensurePosts( [ postId ] );
 			ensuredPromise.done( function( postsData ) {
@@ -603,6 +677,9 @@
 				}
 			} );
 		} );
+
+		// Prevent page_on_front and page_for_posts from being set to be the same.
+		component.preventStaticFrontPageCollision();
 
 		api.previewer.bind( 'focus-control', component.focusControl );
 

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -723,6 +723,8 @@ final class WP_Customize_Posts {
 				'openEditor' => __( 'Open Editor', 'customize-posts' ), // @todo Move this into editor control?
 				'closeEditor' => __( 'Close Editor', 'customize-posts' ),
 				'invalidDateError' => __( 'Whoops, the provided date is invalid.', 'customize-posts' ),
+				/* translators: %s is the trashed page name */
+				'dropdownPagesOptionTrashed' => __( '%s (Trashed)', 'customize-posts' ),
 				'installCustomizeObjectSelector' => sprintf(
 					__( 'This control depends on having the %s plugin installed and activated.', 'customize-posts' ),
 					sprintf(

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -377,10 +377,10 @@ final class WP_Customize_Posts {
 	public function has_published_pages() {
 
 		// @todo Also look to see if there are any pages among in $this->get_setting( 'nav_menus_created_posts' )->value().
+		// Note we cannot use number=>1 since the first-returned page may be previewed to not be published.
 		return 0 !== count( get_pages( array(
 			'post_type' => 'page',
 			'post_status' => 'publish',
-			'number' => 1,
 		) ) );
 	}
 


### PR DESCRIPTION
Continuation of #190.

Fixes #153.