### PR TITLE
Let static_front_page section be contextual instead of controls

### DIFF
--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -167,6 +167,18 @@
 				return;
 			}
 
+			// Add new page to dropdown-pages controls.
+			api.control.each( function( control ) {
+				var select;
+				if ( 'dropdown-pages' === control.params.type ) {
+					select = control.container.find( 'select[name^="_customize-dropdown-pages-"]' );
+					select.append( new Option( api.Posts.data.l10n.noTitle, data.postId ) );
+				}
+			} );
+			if ( api.section.has( 'static_front_page' ) ) {
+				api.section( 'static_front_page' ).activate();
+			}
+
 			deferred.resolve( {
 				postId: data.postId,
 				section: section,

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -312,9 +312,8 @@ final class WP_Customize_Posts {
 				'type' => 'option',
 			) );
 		}
-		$control = $wp_customize->get_control( 'show_on_front' );
-		if ( ! $control ) {
-			$control = $wp_customize->add_control( 'show_on_front', array(
+		if ( ! $wp_customize->get_control( 'show_on_front' ) ) {
+			$wp_customize->add_control( 'show_on_front', array(
 				'label' => __( 'Front page displays', 'default' ),
 				'section' => 'static_front_page',
 				'type' => 'radio',
@@ -324,9 +323,6 @@ final class WP_Customize_Posts {
 				),
 			) );
 		}
-		if ( array( $control, 'active_callback' ) === $control->active_callback ) {
-			$control->active_callback = array( $this, 'has_published_pages' );
-		}
 
 		// Page on Front.
 		if ( ! $wp_customize->get_setting( 'page_on_front' ) ) {
@@ -335,16 +331,12 @@ final class WP_Customize_Posts {
 				'capability' => 'manage_options',
 			) );
 		}
-		$control = $wp_customize->get_control( 'page_on_front' );
-		if ( ! $control ) {
-			$control = $wp_customize->add_control( 'page_on_front', array(
+		if ( ! $wp_customize->get_control( 'page_on_front' ) ) {
+			$wp_customize->add_control( 'page_on_front', array(
 				'label' => __( 'Front page', 'default' ),
 				'section' => 'static_front_page',
 				'type' => 'dropdown-pages',
 			) );
-		}
-		if ( array( $control, 'active_callback' ) === $control->active_callback ) {
-			$control->active_callback = array( $this, 'has_published_pages' );
 		}
 
 		// Page for Posts.
@@ -354,16 +346,12 @@ final class WP_Customize_Posts {
 				'capability' => 'manage_options',
 			) );
 		}
-		$control = $wp_customize->get_control( 'page_for_posts' );
-		if ( ! $control ) {
-			$control = $wp_customize->add_control( 'page_for_posts', array(
+		if ( ! $wp_customize->get_control( 'page_for_posts' ) ) {
+			$wp_customize->add_control( 'page_for_posts', array(
 				'label' => __( 'Posts page', 'default' ),
 				'section' => 'static_front_page',
 				'type' => 'dropdown-pages',
 			) );
-		}
-		if ( array( $control, 'active_callback' ) === $control->active_callback ) {
-			$control->active_callback = array( $this, 'has_published_pages' );
 		}
 	}
 

--- a/tests/php/test-class-wp-customize-posts.php
+++ b/tests/php/test-class-wp-customize-posts.php
@@ -270,7 +270,9 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 		$this->do_customize_boot_actions();
 		$section = $this->wp_customize->get_section( 'static_front_page' );
 		$this->assertInstanceOf( 'WP_Customize_Section', $section );
-		$this->assertEquals( array( $this->posts, 'has_published_pages' ), $section->active_callback );
+		if ( $section->active_callback !== array( $this->wp_customize, 'has_published_pages' ) ) { // Forward-compat, see WP Core Trac #38013.
+			$this->assertEquals( array( $this->posts, 'has_published_pages' ), $section->active_callback );
+		}
 
 		$section->active_callback = array( $section, 'active_callback' ); // Reset to default.
 		$this->posts->ensure_static_front_page_constructs_registered( $this->wp_customize );


### PR DESCRIPTION
Also add newly-created pages immediately to dropdown-pages controls and activate `static_front_page` section immediately.