### PR TITLE
Improve support for page_for_posts by hiding page template and editor while showing notice

### DIFF
--- a/js/customize-page-template.js
+++ b/js/customize-page-template.js
@@ -95,17 +95,28 @@ var CustomizePageTemplate = (function( api ) {
 		/**
 		 * Make sure that control only appears if there are page templates (other than 'default').
 		 *
-		 * @todo The control needs to be deactivated when the page is the same as wp.customize( 'page_on_front' ).get().
+		 * Also only show page template if the page is not the page_for_posts.
+		 *
+		 * @link https://github.com/xwp/wordpress-develop/blob/4.6.0/src/wp-admin/includes/meta-boxes.php#L820
+		 *
 		 * @todo Page-specific templates also need to be accounted for here (the 'theme_page_templates' filter in PHP).
 		 *
 		 * @returns {boolean} Is active.
 		 */
 		isActiveCallback = function() {
 			var defaultSize = 1;
+			if ( api.has( 'page_for_posts' ) && parseInt( api( 'page_for_posts' ).get(), 10 ) === section.params.post_id ) {
+				return false;
+			}
 			return _.size( control.params.choices ) > defaultSize;
 		};
 		control.active.set( isActiveCallback() );
 		control.active.validate = isActiveCallback;
+		api( 'page_for_posts', function( pageOnFrontSetting ) {
+			pageOnFrontSetting.bind( function() {
+				control.active.set( isActiveCallback() );
+			} );
+		} );
 
 		// Register.
 		api.control.add( control.id, control );

--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -195,7 +195,7 @@
 		 */
 		embedSectionContents: function embedSectionContents() {
 			var section = this;
-			section.setupSettingValidation();
+			section.setupSectionNotifications();
 			section.setupPostNavigation();
 			section.setupControls();
 		},
@@ -823,12 +823,12 @@
 		},
 
 		/**
-		 * Set up setting validation.
+		 * Set up section notifications.
 		 *
 		 * @returns {void}
 		 */
-		setupSettingValidation: function() {
-			var section = this, setting = api( section.id ), debouncedRenderNotifications;
+		setupSectionNotifications: function() {
+			var section = this, setting = api( section.id ), debouncedRenderNotifications, setPageForPostsNotice;
 			if ( ! setting.notifications ) {
 				return;
 			}
@@ -915,6 +915,29 @@
 
 			api.bind( 'save', function() {
 				section.resetPostFieldControlErrorNotifications();
+			} );
+
+			/**
+			 * Add notice when editing the page for posts.
+			 *
+			 * @see _wp_posts_page_notice() in PHP
+			 * @returns {void}
+			 */
+			setPageForPostsNotice = function() {
+				var code = 'editing_page_for_posts';
+				if ( section.isPageForPosts() ) {
+					section.notifications.add( code, new api.Notification( code, {
+						message: api.Posts.data.l10n.editingPageForPostsNotice,
+						type: 'warning'
+					} ) );
+				} else {
+					section.notifications.remove( code );
+				}
+			};
+
+			api( 'page_for_posts', function( pageForPostsSetting ) {
+				setPageForPostsNotice();
+				pageForPostsSetting.bind( setPageForPostsNotice );
 			} );
 		},
 

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -715,6 +715,7 @@ final class WP_Customize_Posts {
 				'dropdownPagesOptionTrashed' => __( '%s (Trashed)', 'customize-posts' ),
 				/* translators: %s is the trashed page name */
 				'dropdownPagesOptionUnpublished' => __( '%s (Unpublished)', 'customize-posts' ),
+				'editingPageForPostsNotice' => __( 'You are currently editing the page that shows your latest posts.', 'default' ),
 				'editPostFailure' => __( 'Failed to open for editing.', 'customize-posts' ),
 				'createPostFailure' => __( 'Failed to create for editing.', 'customize-posts' ),
 				'installCustomizeObjectSelector' => sprintf(


### PR DESCRIPTION
<img width="269" alt="customize__entradas_ _wordpress_develops" src="https://cloud.githubusercontent.com/assets/134745/18613323/a9deaf4a-7d2c-11e6-94ad-1c1ac2b1a096.png">

Fixes #228
Fixes #277