### PR TITLE
Prevent editor from inadvertently closing with ESC; ensure TinyMCE toolbars hide when collapsed

### DIFF
--- a/css/customize-posts.css
+++ b/css/customize-posts.css
@@ -239,12 +239,6 @@ body.customize-posts-content-editor-pane-resize #customize-preview:before {
 	z-index: 500100 !important; /* originally 100100, but z-index of .wp-full-overlay is 500000 */
 }
 
-body:not( .customize-posts-content-editor-pane-open ) > .mce-toolbar-grp,
-body:not( .customize-posts-content-editor-pane-open ) > .mce-widget,
-body:not( .customize-posts-content-editor-pane-open ) > .wplink-autocomplete {
-	display: none;
-}
-
 .customize-posts-content-editor-pane-open .wp-full-overlay.collapsed .wp-full-overlay-sidebar {
 	z-index: 30;
 }

--- a/css/customize-posts.css
+++ b/css/customize-posts.css
@@ -239,6 +239,12 @@ body.customize-posts-content-editor-pane-resize #customize-preview:before {
 	z-index: 500100 !important; /* originally 100100, but z-index of .wp-full-overlay is 500000 */
 }
 
+body:not( .customize-posts-content-editor-pane-open ) > .mce-toolbar-grp,
+body:not( .customize-posts-content-editor-pane-open ) > .mce-widget,
+body:not( .customize-posts-content-editor-pane-open ) > .wplink-autocomplete {
+	display: none;
+}
+
 .customize-posts-content-editor-pane-open .wp-full-overlay.collapsed .wp-full-overlay-sidebar {
 	z-index: 30;
 }

--- a/js/customize-post-editor-control.js
+++ b/js/customize-post-editor-control.js
@@ -161,12 +161,14 @@
 				}
 				editor.on( 'input change keyup', control.onVisualEditorChange );
 				control.contentTextarea.on( 'input', control.onTextEditorChange );
+				$( '#wp-customize-posts-content-wrap' ).on( 'keydown', control.stopEscKeypressEventPropagation );
 				$( document.body ).addClass( 'customize-posts-content-editor-pane-open' );
 				control.resizeEditor( window.innerHeight - control.editorPane.height() );
 			} else {
 				control.editorHeading.text( '' );
 				editor.off( 'input change keyup', control.onVisualEditorChange );
 				control.contentTextarea.off( 'input', control.onTextEditorChange );
+				$( '#wp-customize-posts-content-wrap' ).off( 'keydown', control.stopEscKeypressEventPropagation );
 				$( document.body ).removeClass( 'customize-posts-content-editor-pane-open' );
 
 				// Cancel link and force a click event to exit fullscreen & kitchen sink mode.
@@ -521,6 +523,22 @@
 					}
 				}
 			});
+		},
+
+		/**
+		 * Stop propagation of escape key to prevent the editor control from being collapsed.
+		 *
+		 * This stops the following code from running in core:
+		 * https://github.com/xwp/wordpress-develop/blob/4.6.1/src/wp-admin/js/customize-controls.js#L3971-L4007
+		 *
+		 * @param {jQuery.Event} event Event.
+		 * @returns {void}
+		 */
+		stopEscKeypressEventPropagation: function( event ) {
+			var escKeyCode = 27;
+			if ( escKeyCode === event.which ) {
+				event.stopPropagation();
+			}
 		}
 	});
 

--- a/js/customize-post-editor-control.js
+++ b/js/customize-post-editor-control.js
@@ -4,6 +4,9 @@
 (function( api, $ ) {
 	'use strict';
 
+	// This is true because wp_editor() is forcibly called with 'default_editor' => 'tinymce'.
+	var visualModeEnabled = true;
+
 	/**
 	 * An post editor control.
 	 *
@@ -154,7 +157,10 @@
 				control.collapseOtherControls();
 				control.updateEditorHeading();
 
-				if ( editor && ! editor.isHidden() ) {
+				if ( visualModeEnabled ) {
+					editor.show();
+				}
+				if ( editor && visualModeEnabled ) {
 					editor.setContent( wp.editor.autop( settingValue ) );
 				} else {
 					control.contentTextarea.val( settingValue );
@@ -172,8 +178,9 @@
 				$( document.body ).removeClass( 'customize-posts-content-editor-pane-open' );
 
 				// Cancel link and force a click event to exit fullscreen & kitchen sink mode.
-				editor.execCommand( 'wp_link_cancel' );
-				$( '.mce-active' ).click();
+				$( '.mce-active' ).click(); // Remove active status from each item. @todo This is a hack.
+				visualModeEnabled = ! editor.isHidden();
+				editor.hide(); // Make sure all toolbars are hidden.
 				control.customizePreview.css( 'bottom', '' );
 				control.collapseSidebar.css( 'bottom', '' );
 			}

--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -1023,6 +1023,21 @@
 		return autofocusPostIds;
 	};
 
+	/*
+	 * Abort if the event target is not the body (the default) and not inside of #customize-controls.
+	 * This ensures that ESC meant to collapse a modal dialog or a TinyMCE toolbar won't collapse something else.
+	 *
+	 * See https://core.trac.wordpress.org/ticket/38091
+	 *
+	 * @todo As as the fix lands in core, this logic should be conditionally run only if version if 4.6.0 or 4.6.1, assuming it makes it into 4.6.2
+	 */
+	$( 'body' ).on( 'keydown', function( event ) {
+		var escKey = 27;
+		if ( escKey === event.which && ! $( event.target ).is( 'body' ) && ! $.contains( $( '#customize-controls' )[0], event.target ) ) {
+			event.stopImmediatePropagation();
+		}
+	} );
+
 	api.bind( 'ready', function() {
 
 		// Add a post_ID input for editor integrations (like Shortcake) to be able to know the post being edited.


### PR DESCRIPTION
Fixes #281
Fixes #231