### PR TITLE
Fix broken getCurrentTime() method in Safari 

### DIFF
--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -533,7 +533,7 @@
 	component.getCurrentTime = function getCurrentTime() {
 		var currentDate, currentTimestamp, timestampDifferential;
 		currentTimestamp = ( new Date() ).valueOf();
-		currentDate = new Date( component.data.initialServerDate );
+		currentDate = new Date( component.data.initialServerDate.replace( ' ', 'T' ) );
 		timestampDifferential = currentTimestamp - component.data.initialClientTimestamp;
 		timestampDifferential += component.data.initialClientTimestamp - component.data.initialServerTimestamp;
 		currentDate.setTime( currentDate.getTime() + timestampDifferential );


### PR DESCRIPTION
In Safari, but not other browsers, `new Date( "2016-09-23 14:57:10" )` is an *Invalid Date*. It turns out that including `T` delimiting the date from the time causes it to work in Safari, so this PR implements that.