### PR TITLE
Release 0.8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "xwp/wp-customize-posts",
 	"description": "Manage posts and postmeta via the Customizer.",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"type": "wordpress-plugin",
 	"keywords": [ "customizer", "customize", "posts", "postmeta", "preview", "featured-image", "page-template" ],
 	"homepage": "https://github.com/xwp/wp-customize-posts/",

--- a/customize-posts.php
+++ b/customize-posts.php
@@ -3,7 +3,7 @@
  * Plugin Name: Customize Posts
  * Description: Manage posts and postmeta via the Customizer. Works best in conjunction with the <a href="https://wordpress.org/plugins/customize-setting-validation/">Customize Setting Validation</a> plugin.
  * Plugin URI: https://github.com/xwp/wp-customize-posts/
- * Version: 0.8.0
+ * Version: 0.8.1
  * Author: XWP
  * Author URI: https://make.xwp.co/
  * License: GPLv2+

--- a/js/customize-post-editor-control.js
+++ b/js/customize-post-editor-control.js
@@ -100,8 +100,8 @@
 		/**
 		 * Toggle the expanded control.
 		 *
-		 * @param {Boolean} expanded
-		 * @param {Object} [params]
+		 * @param {Boolean} expanded Expanded.
+		 * @param {Object} [params]  Params.
 		 * @returns {Boolean} false if state already applied
 		 */
 		_toggleExpanded: function( expanded, params ) {

--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -533,7 +533,7 @@
 	component.getCurrentTime = function getCurrentTime() {
 		var currentDate, currentTimestamp, timestampDifferential;
 		currentTimestamp = ( new Date() ).valueOf();
-		currentDate = new Date( component.data.initialServerDate );
+		currentDate = new Date( component.data.initialServerDate.replace( ' ', 'T' ) );
 		timestampDifferential = currentTimestamp - component.data.initialClientTimestamp;
 		timestampDifferential += component.data.initialClientTimestamp - component.data.initialServerTimestamp;
 		currentDate.setTime( currentDate.getTime() + timestampDifferential );

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/xwp/wp-customize-posts.git"
   },
-  "version": "0.8.0",
+  "version": "0.8.1",
   "license": "GPL-2.0+",
   "private": true,
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Edit posts and postmeta in the Customizer. Stop editing your posts/postmeta blin
 **Tags:** [customizer](https://wordpress.org/plugins/tags/customizer), [customize](https://wordpress.org/plugins/tags/customize), [posts](https://wordpress.org/plugins/tags/posts), [postmeta](https://wordpress.org/plugins/tags/postmeta), [editor](https://wordpress.org/plugins/tags/editor), [preview](https://wordpress.org/plugins/tags/preview), [featured-image](https://wordpress.org/plugins/tags/featured-image), [page-template](https://wordpress.org/plugins/tags/page-template)  
 **Requires at least:** 4.5  
 **Tested up to:** 4.7-alpha  
-**Stable tag:** 0.8.0  
+**Stable tag:** 0.8.1  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 
 [![Build Status](https://travis-ci.org/xwp/wp-customize-posts.svg?branch=master)](https://travis-ci.org/xwp/wp-customize-posts) [![Coverage Status](https://coveralls.io/repos/xwp/wp-customize-posts/badge.svg?branch=master)](https://coveralls.io/github/xwp/wp-customize-posts) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.svg)](http://gruntjs.com) [![devDependency Status](https://david-dm.org/xwp/wp-customize-posts/dev-status.svg)](https://david-dm.org/xwp/wp-customize-posts#info=devDependencies) 
@@ -89,6 +89,9 @@ The following are listed in reverse chronological order. The first, more recent 
 ![[0.8.0] Post parent and basic menu order control.](wp-assets/screenshot-7.png)
 
 ## Changelog ##
+
+### [0.8.1] - 2016-09-23 ###
+Fixed compatibility with Safari in the <code>wp.customize.Posts.getCurrentTime()</code> method. See <a href="https://github.com/xwp/wp-customize-posts/pull/293" class="issue-link js-issue-link" data-url="https://github.com/xwp/wp-customize-posts/issues/293" data-id="178983334" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#293</a>. Props Piotr Delawski (<a href="https://github.com/delawski" class="user-mention">@delawski</a>).
 
 ### [0.8.0] - 2016-09-22 ###
 Added:

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      xwp, westonruter, valendesigns
 Tags:              customizer, customize, posts, postmeta, editor, preview, featured-image, page-template
 Requires at least: 4.5
 Tested up to:      4.7-alpha
-Stable tag:        0.8.0
+Stable tag:        0.8.1
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,10 @@ The following are listed in reverse chronological order. The first, more recent 
 7. [0.8.0] Post parent and basic menu order control.
 
 == Changelog ==
+
+= [0.8.1] - 2016-09-23 =
+
+Fixed compatibility with Safari in the <code>wp.customize.Posts.getCurrentTime()</code> method. See <a href="https://github.com/xwp/wp-customize-posts/pull/293" class="issue-link js-issue-link" data-url="https://github.com/xwp/wp-customize-posts/issues/293" data-id="178983334" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#293</a>. Props Piotr Delawski (<a href="https://github.com/delawski" class="user-mention">@delawski</a>).
 
 = [0.8.0] - 2016-09-22 =
 


### PR DESCRIPTION
- [x] Add contributor props.
- [x] Bump version numbers. `ack -Q 0.8.0` and replace with `0.8.1` where appropriate (this needs to be automated)
- [x] Test build.
- [x] Add changelog to readme.
- [x] Make new GitHub release tag `0.8.1` on `master`, with ZIP build via `grunt build; cd build; zip -r ../customize-posts-0.8.1.zip *; cd -`, and with link to readme on tag tree: https://github.com/xwp/wp-customize-posts/blob/0.8.1/readme.md#changelog
- [x] Deploy to WordPress.org