### PR TITLE
Release 0.8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "xwp/wp-customize-posts",
 	"description": "Manage posts and postmeta via the Customizer.",
-	"version": "0.8.1",
+	"version": "0.8.2",
 	"type": "wordpress-plugin",
 	"keywords": [ "customizer", "customize", "posts", "postmeta", "preview", "featured-image", "page-template" ],
 	"homepage": "https://github.com/xwp/wp-customize-posts/",

--- a/customize-posts.php
+++ b/customize-posts.php
@@ -3,7 +3,7 @@
  * Plugin Name: Customize Posts
  * Description: Manage posts and postmeta via the Customizer. Works best in conjunction with the <a href="https://wordpress.org/plugins/customize-setting-validation/">Customize Setting Validation</a> plugin.
  * Plugin URI: https://github.com/xwp/wp-customize-posts/
- * Version: 0.8.1
+ * Version: 0.8.2
  * Author: XWP
  * Author URI: https://make.xwp.co/
  * License: GPLv2+

--- a/js/customize-post-date-control.js
+++ b/js/customize-post-date-control.js
@@ -183,8 +183,8 @@
 				return;
 			}
 
-			remainingTime = ( new Date( control.setting.get().post_date ) ).valueOf();
-			remainingTime -= ( new Date( api.Posts.getCurrentTime() ) ).valueOf();
+			remainingTime = api.Posts.parsePostDate( control.setting.get().post_date ).valueOf();
+			remainingTime -= api.Posts.parsePostDate( api.Posts.getCurrentTime() ).valueOf();
 			remainingTime = Math.ceil( remainingTime / 1000 );
 			if ( remainingTime > 0 ) {
 				control.scheduledCountdownContainer.text( control.scheduledCountdownTemplate( { remainingTime: remainingTime } ) );

--- a/js/customize-post-status-control.js
+++ b/js/customize-post-status-control.js
@@ -110,8 +110,8 @@
 		 */
 		updateChoices: function updateChoices() {
 			var control = this, data = control.setting.get(), isFuture, postTimestamp, currentTimestamp;
-			postTimestamp = ( new Date( data.post_date ) ).valueOf();
-			currentTimestamp = ( new Date( api.Posts.getCurrentTime() ) ).valueOf();
+			postTimestamp = api.Posts.parsePostDate( data.post_date );
+			currentTimestamp = api.Posts.parsePostDate( api.Posts.getCurrentTime() );
 			isFuture = postTimestamp > currentTimestamp;
 
 			/*
@@ -119,6 +119,8 @@
 			 * when server time and client time aren't exactly aligned. If the
 			 * status is publish, and yet the post date is less than 15 seconds
 			 * into the future, consider it as not future.
+			 *
+			 * See also https://github.com/xwp/wp-customize-posts/issues/303
 			 */
 			if ( isFuture && 'publish' === data.post_status && postTimestamp - currentTimestamp < 15 * 1000 ) {
 				isFuture = false;

--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -534,11 +534,24 @@
 	component.getCurrentTime = function getCurrentTime() {
 		var currentDate, currentTimestamp, timestampDifferential;
 		currentTimestamp = ( new Date() ).valueOf();
-		currentDate = new Date( component.data.initialServerDate.replace( ' ', 'T' ) );
+		currentDate = component.parsePostDate( component.data.initialServerDate );
 		timestampDifferential = currentTimestamp - component.data.initialClientTimestamp;
 		timestampDifferential += component.data.initialClientTimestamp - component.data.initialServerTimestamp;
 		currentDate.setTime( currentDate.getTime() + timestampDifferential );
 		return component.formatDate( currentDate );
+	};
+
+	/**
+	 * Parse post date string in YYYY-MM-DD HH:MM:SS format (local timezone).
+	 *
+	 * @param {string} postDate Post date string.
+	 * @returns {Date} Parsed date.
+	 */
+	component.parsePostDate = function parsePostDate( postDate ) {
+		var dateParts = _.map( postDate.split( /\D/ ), function( datePart ) {
+			return parseInt( datePart, 10 );
+		} );
+		return new Date( dateParts[0], dateParts[1] - 1, dateParts[2], dateParts[3], dateParts[4], dateParts[5] ); // eslint-disable-line no-magic-numbers
 	};
 
 	/**

--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -308,6 +308,7 @@
 		request = wp.ajax.post( 'customize-posts-fetch-settings', {
 			'customize-posts-nonce': api.settings.nonce['customize-posts'],
 			'wp_customize': 'on',
+			'customized': api.previewer.query().customized,
 			'post_ids': newPostIds
 		} );
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/xwp/wp-customize-posts.git"
   },
-  "version": "0.8.1",
+  "version": "0.8.2",
   "license": "GPL-2.0+",
   "private": true,
   "devDependencies": {

--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -860,9 +860,18 @@ final class WP_Customize_Posts_Preview {
 			/**
 			 * Filter the postmeta rows that are being previewed.
 			 *
-			 * @param array $postmeta_rows Postmeta rows, associative arrays with keys for post_id, meta_key, and meta_value.
+			 * @param array $postmeta_rows                   Postmeta rows, associative arrays with keys for post_id, meta_key, and meta_value.
+			 * @param WP_Customize_Postmeta_Setting $setting Post meta setting.
 			 */
-			$postmeta_rows = apply_filters( 'customize_previewed_postmeta_rows', $postmeta_rows );
+			$postmeta_rows = apply_filters( 'customize_previewed_postmeta_rows', $postmeta_rows, $setting );
+
+			/**
+			 * Filter the postmeta rows that are being previewed for a specific key.
+			 *
+			 * @param array                         $postmeta_rows Postmeta rows, associative arrays with keys for post_id, meta_key, and meta_value.
+			 * @param WP_Customize_Postmeta_Setting $setting       Post meta setting.
+			 */
+			$postmeta_rows = apply_filters( "customize_previewed_postmeta_rows_{$setting->meta_key}", $postmeta_rows, $setting );
 
 			$previewed_meta_keys = wp_list_pluck( $postmeta_rows, 'meta_key' );
 

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -1322,25 +1322,32 @@ final class WP_Customize_Posts {
 			wp_send_json_error( 'bad_post_ids' );
 		}
 
+		$this->manager->add_dynamic_settings( array_keys( $this->manager->unsanitized_post_values() ) );
+
 		$setting_params = array();
 		$settings = $this->get_settings( $post_ids );
 		foreach ( $settings as $setting ) {
 			if ( $setting->check_capabilities() ) {
+				$setting->preview();
 				$setting_params[ $setting->id ] = $this->get_setting_params( $setting );
 			}
 		}
 
 		// Return with a failure if any of the requested posts.
 		foreach ( $post_ids as $post_id ) {
-			$post = get_post( $post_id );
-			if ( empty( $post ) ) {
-				status_header( 404 );
-				wp_send_json_error( 'requested_post_absent' );
-			}
-			if ( 'nav_menu_item' === $post->post_type ) {
-				$setting_id = sprintf( 'nav_menu_item[%d]', $post->ID );
+			if ( $post_id < 0 ) {
+				$post_type = 'nav_menu_item';
 			} else {
-				$setting_id = WP_Customize_Post_Setting::get_post_setting_id( $post );
+				$post_type = get_post_type( $post_id );
+				if ( empty( $post_type ) ) {
+					status_header( 404 );
+					wp_send_json_error( 'requested_post_absent' );
+				}
+			}
+			if ( 'nav_menu_item' === $post_type ) {
+				$setting_id = sprintf( 'nav_menu_item[%d]', $post_id );
+			} else {
+				$setting_id = WP_Customize_Post_Setting::get_post_setting_id( get_post( $post_id ) );
 			}
 			if ( ! isset( $setting_params[ $setting_id ] ) ) {
 				status_header( 404 );

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ Edit posts and postmeta in the Customizer. Stop editing your posts/postmeta blin
 **Tags:** [customizer](https://wordpress.org/plugins/tags/customizer), [customize](https://wordpress.org/plugins/tags/customize), [posts](https://wordpress.org/plugins/tags/posts), [postmeta](https://wordpress.org/plugins/tags/postmeta), [editor](https://wordpress.org/plugins/tags/editor), [preview](https://wordpress.org/plugins/tags/preview), [featured-image](https://wordpress.org/plugins/tags/featured-image), [page-template](https://wordpress.org/plugins/tags/page-template)  
 **Requires at least:** 4.5  
 **Tested up to:** 4.7-alpha  
-**Stable tag:** 0.8.1  
+**Stable tag:** 0.8.2  
 **License:** [GPLv2 or later](http://www.gnu.org/licenses/gpl-2.0.html)  
 
 [![Build Status](https://travis-ci.org/xwp/wp-customize-posts.svg?branch=master)](https://travis-ci.org/xwp/wp-customize-posts) [![Coverage Status](https://coveralls.io/repos/xwp/wp-customize-posts/badge.svg?branch=master)](https://coveralls.io/github/xwp/wp-customize-posts) [![Built with Grunt](https://cdn.gruntjs.com/builtwith.svg)](http://gruntjs.com) [![devDependency Status](https://david-dm.org/xwp/wp-customize-posts/dev-status.svg)](https://david-dm.org/xwp/wp-customize-posts#info=devDependencies) 
@@ -89,6 +89,15 @@ The following are listed in reverse chronological order. The first, more recent 
 ![[0.8.0] Post parent and basic menu order control.](wp-assets/screenshot-7.png)
 
 ## Changelog ##
+
+### [0.8.2] - 2016-10-03 ###
+* Fixed browser incompatible way of parsing local datetime strings. This is a follow-up on <a href="https://github.com/xwp/wp-customize-posts/pull/293" class="issue-link js-issue-link" data-url="https://github.com/xwp/wp-customize-posts/issues/293" data-id="178983334" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#293</a>, which was not fully fixed in 0.8.1. PR <a href="https://github.com/xwp/wp-customize-posts/pull/304" class="issue-link js-issue-link" data-url="https://github.com/xwp/wp-customize-posts/issues/304" data-id="180808420" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#304</a>.
+ * Improved fetching of post/postmeta settings so that the <code>customized</code> state is included in the request, and allow for placeholder <code>nav_menu_item</code> settings to be fetched. PR <a href="https://github.com/xwp/wp-customize-posts/pull/299" class="issue-link js-issue-link" data-url="https://github.com/xwp/wp-customize-posts/issues/299" data-id="180154206" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#299</a>.
+ * Added <code>$setting</code> context to <code>customize_previewed_postmeta_rows</code> filter and add new <code>customize_previewed_postmeta_rows_{$setting-&gt;post_meta}</code> filter. PR <a href="https://github.com/xwp/wp-customize-posts/pull/299" class="issue-link js-issue-link" data-url="https://github.com/xwp/wp-customize-posts/issues/299" data-id="180154206" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#299</a>.
+
+Props Weston Ruter (<a href="https://github.com/westonruter" class="user-mention">@westonruter</a>), Utkarsh Patel (<a href="https://github.com/PatelUtkarsh" class="user-mention">@PatelUtkarsh</a>).
+
+See <a href="https://github.com/xwp/wp-customize-posts/milestone/10?closed=1">issues and PRs in milestone</a> and <a href="https://github.com/xwp/wp-customize-posts/compare/0.8.1...0.8.2">full release commit log</a>.
 
 ### [0.8.1] - 2016-09-23 ###
 Fixed compatibility with Safari in the <code>wp.customize.Posts.getCurrentTime()</code> method. See <a href="https://github.com/xwp/wp-customize-posts/pull/293" class="issue-link js-issue-link" data-url="https://github.com/xwp/wp-customize-posts/issues/293" data-id="178983334" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#293</a>. Props Piotr Delawski (<a href="https://github.com/delawski" class="user-mention">@delawski</a>).

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors:      xwp, westonruter, valendesigns
 Tags:              customizer, customize, posts, postmeta, editor, preview, featured-image, page-template
 Requires at least: 4.5
 Tested up to:      4.7-alpha
-Stable tag:        0.8.1
+Stable tag:        0.8.2
 License:           GPLv2 or later
 License URI:       http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -66,6 +66,16 @@ The following are listed in reverse chronological order. The first, more recent 
 7. [0.8.0] Post parent and basic menu order control.
 
 == Changelog ==
+
+= [0.8.2] - 2016-10-03 =
+
+ * Fixed browser incompatible way of parsing local datetime strings. This is a follow-up on <a href="https://github.com/xwp/wp-customize-posts/pull/293" class="issue-link js-issue-link" data-url="https://github.com/xwp/wp-customize-posts/issues/293" data-id="178983334" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#293</a>, which was not fully fixed in 0.8.1. PR <a href="https://github.com/xwp/wp-customize-posts/pull/304" class="issue-link js-issue-link" data-url="https://github.com/xwp/wp-customize-posts/issues/304" data-id="180808420" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#304</a>.
+ * Improved fetching of post/postmeta settings so that the <code>customized</code> state is included in the request, and allow for placeholder <code>nav_menu_item</code> settings to be fetched. PR <a href="https://github.com/xwp/wp-customize-posts/pull/299" class="issue-link js-issue-link" data-url="https://github.com/xwp/wp-customize-posts/issues/299" data-id="180154206" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#299</a>.
+ * Added <code>$setting</code> context to <code>customize_previewed_postmeta_rows</code> filter and add new <code>customize_previewed_postmeta_rows_{$setting-&gt;post_meta}</code> filter. PR <a href="https://github.com/xwp/wp-customize-posts/pull/299" class="issue-link js-issue-link" data-url="https://github.com/xwp/wp-customize-posts/issues/299" data-id="180154206" data-error-text="Failed to load issue title" data-permission-text="Issue title is private">#299</a>.
+
+Props Weston Ruter (<a href="https://github.com/westonruter" class="user-mention">@westonruter</a>), Utkarsh Patel (<a href="https://github.com/PatelUtkarsh" class="user-mention">@PatelUtkarsh</a>).
+
+See <a href="https://github.com/xwp/wp-customize-posts/milestone/10?closed=1">issues and PRs in milestone</a> and <a href="https://github.com/xwp/wp-customize-posts/compare/0.8.1...0.8.2">full release commit log</a>.
 
 = [0.8.1] - 2016-09-23 =
 


### PR DESCRIPTION
- [x] Add contributor props.
- [x] Bump version numbers. `ack -Q 0.8.1` and replace with `0.8.2` where appropriate (this needs to be automated)
- [x] Test build.
- [x] Add changelog to readme.
- [ ] Draft new GitHub release tag `0.8.2` on `master`, with ZIP build via `grunt build; cd build; zip -r ../customize-posts-0.8.2.zip *; cd -`, and with link to readme on tag tree: https://github.com/xwp/wp-customize-posts/blob/0.8.2/readme.md#changelog
- [ ] Merge release PR.
- [ ] Publish GitHub release.
- [ ] Deploy to WordPress.org via `grunt deploy`. Remember to look at SVN diff.