### PR TITLE
Prevent extra section params from being passed along to previewUrl

### DIFF
--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -254,7 +254,10 @@
 
 			sectionNavigationButton.on( 'click', function( event ) {
 				event.preventDefault();
-				api.previewer.previewUrl( api.Posts.getPreviewUrl( section.params ) );
+				api.previewer.previewUrl( api.Posts.getPreviewUrl( {
+					post_id: section.params.post_id,
+					post_type: section.params.post_type
+				} ) );
 			} );
 		},
 

--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -106,7 +106,7 @@
 	 * @param {object} params - Query vars.
 	 * @param {number} params.post_id - Post ID.
 	 * @param {string} [params.post_type] - Post type.
-	 * @param {boolean} [params.preview] - .
+	 * @param {boolean} [params.preview] - Preview.
 	 * @return {string} Preview URL.
 	 */
 	component.getPostUrl = function getPostUrl( params ) {


### PR DESCRIPTION
Prevent the `section.params` other than `post_id` and `post_type` from being included in preview URL. Prevents URLs from being previewed that look like:

http://wp.example.com/?preview=true&p=6189&id=post%5Bpost%5D%5B6189%5D&panel=posts%5Bpost%5D&active=true&customizeAction=Customizing%2B%E2%96%B8%2BPosts&title=Hello%2BWorld&description=&priority=100&type=default&content=&instanceNumber=

The issue happened specifically when you clicked the post navigation link or if you jumped to a post via the select2 and the post was not visible in the preview:

<img width="297" alt="Jump to post" src="https://cloud.githubusercontent.com/assets/134745/19096009/22744496-8a4e-11e6-9f95-94255844f040.png">
