### PR TITLE
Restore edit_post_link() in WordPress 4.7

### DIFF
--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -99,6 +99,7 @@ final class WP_Customize_Posts_Preview {
 		add_filter( 'get_avatar', array( $this, 'filter_get_avatar' ), 10, 6 );
 		add_filter( 'infinite_scroll_results', array( $this, 'amend_with_queried_post_ids' ) );
 		add_filter( 'customize_render_partials_response', array( $this, 'amend_with_queried_post_ids' ) );
+		remove_filter( 'get_edit_post_link', '__return_empty_string' ); // See <https://core.trac.wordpress.org/ticket/38648>.
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-page-template-controller.php
+++ b/tests/php/test-class-wp-customize-page-template-controller.php
@@ -146,7 +146,7 @@ class Test_WP_Customize_Page_Template_Controller extends WP_UnitTestCase {
 		$has_setting_validation = method_exists( 'WP_Customize_Setting', 'validate' );
 
 		$controller = new WP_Customize_Page_Template_Controller();
-		$post = get_post( $this->factory()->post->create() );
+		$post = get_post( $this->factory()->post->create( array( 'post_type' => 'page' ) ) );
 		$setting_id = WP_Customize_Postmeta_Setting::get_post_meta_setting_id( $post, $controller->meta_key );
 		$setting = new WP_Customize_Postmeta_Setting( $this->wp_customize, $setting_id );
 

--- a/tests/php/test-class-wp-customize-postmeta-setting.php
+++ b/tests/php/test-class-wp-customize-postmeta-setting.php
@@ -286,7 +286,7 @@ class Test_Customize_Postmeta_Setting extends WP_UnitTestCase {
 	function test_sanitize_page_template_setting() {
 		switch_theme( 'twentytwelve' );
 
-		$post_id = $this->factory()->post->create( array( 'post_type' => 'post') );
+		$post_id = $this->factory()->post->create( array( 'post_type' => 'page' ) );
 		$meta_key = '_wp_page_template';
 		register_meta( 'post', $meta_key, array( $this->plugin->page_template_controller, 'sanitize_value' ) );
 		$setting_id = WP_Customize_Postmeta_Setting::get_post_meta_setting_id( get_post( $post_id ), $meta_key );


### PR DESCRIPTION
See https://core.trac.wordpress.org/ticket/38648