### PR TITLE
Eliminate determination of user capability in setting constructor

### DIFF
--- a/php/class-wp-customize-post-setting.php
+++ b/php/class-wp-customize-post-setting.php
@@ -92,20 +92,9 @@ class WP_Customize_Post_Setting extends WP_Customize_Setting {
 			throw new Exception( 'Posts component not instantiated.' );
 		}
 		$this->posts_component = $manager->posts;
-		$update = $args['post_id'] > 0;
-		$post_type_obj = get_post_type_object( $args['post_type'] );
 
-		// Determine capability for editing this.
-		$can_edit = false;
-		if ( $update ) {
-			$can_edit = $this->posts_component->current_user_can_edit_post( $args['post_id'] );
-		} elseif ( $post_type_obj ) {
-			$can_edit = current_user_can( $post_type_obj->cap->edit_posts );
-		}
-		if ( $can_edit ) {
-			$args['capability'] = $post_type_obj->cap->edit_posts;
-		} else {
-			$args['capability'] = 'do_not_allow';
+		if ( empty( $args['capability'] ) ) {
+			$args['capability'] = sprintf( 'edit_post[%d]', $args['post_id'] );
 		}
 
 		parent::__construct( $manager, $id, $args );

--- a/php/class-wp-customize-postmeta-setting.php
+++ b/php/class-wp-customize-postmeta-setting.php
@@ -102,16 +102,8 @@ class WP_Customize_Postmeta_Setting extends WP_Customize_Setting {
 			$args['default'] = array();
 		}
 
-		// Determine the capability required for editing this.
-		$post_type_obj = get_post_type_object( $args['post_type'] );
-		$can_edit = $this->posts_component->current_user_can_edit_post( $args['post_id'] );
-		if ( $can_edit ) {
-			$can_edit = current_user_can( 'edit_post_meta', $args['post_id'], $args['meta_key'] );
-		}
-		if ( ! $can_edit ) {
-			$args['capability'] = 'do_not_allow';
-		} elseif ( ! isset( $args['capability'] ) ) {
-			$args['capability'] = $post_type_obj->cap->edit_posts;
+		if ( empty( $args['capability'] ) ) {
+			$args['capability'] = sprintf( 'edit_post_meta[%d][%s]', $args['post_id'], $args['meta_key'] );
 		}
 		parent::__construct( $manager, $id, $args );
 	}

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -92,6 +92,7 @@ final class WP_Customize_Posts {
 		add_filter( 'customize_refresh_nonces', array( $this, 'add_customize_nonce' ) );
 		add_action( 'customize_register', array( $this, 'ensure_static_front_page_constructs_registered' ), 11 );
 		add_action( 'customize_register', array( $this, 'register_constructs' ), 20 );
+		add_filter( 'map_meta_cap', array( $this, 'filter_map_meta_cap' ), 10, 4 );
 		add_action( 'init', array( $this, 'register_meta' ), 100 );
 		add_filter( 'customize_dynamic_setting_args', array( $this, 'filter_customize_dynamic_setting_args' ), 10, 2 );
 		add_filter( 'customize_dynamic_setting_class', array( $this, 'filter_customize_dynamic_setting_class' ), 5, 3 );
@@ -451,6 +452,28 @@ final class WP_Customize_Posts {
 			// Note the following is an alternative to doing WP_Customize_Manager::register_panel_type().
 			add_action( 'customize_controls_print_footer_scripts', array( $panel, 'print_template' ) );
 		}
+	}
+
+	/**
+	 * Map dynamic post/postmeta capabilities to static capabilities.
+	 *
+	 * @param array  $caps    Returns the user's actual capabilities.
+	 * @param string $cap     Capability name.
+	 * @param int    $user_id The user ID.
+	 * @return array Caps.
+	 */
+	public function filter_map_meta_cap( $caps, $cap, $user_id ) {
+		if ( preg_match( '/^(?:edit_post|edit_post_meta)\[\d+/', $cap ) ) {
+			$keys = explode( '[', str_replace( ']', '', $cap ) );
+			$map_meta_cap_args = array(
+				array_shift( $keys ),
+				$user_id,
+				intval( array_shift( $keys ) ),
+				array_shift( $keys ),
+			);
+			$caps = call_user_func_array( 'map_meta_cap', $map_meta_cap_args );
+		}
+		return $caps;
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-post-setting.php
+++ b/tests/php/test-class-wp-customize-post-setting.php
@@ -137,31 +137,17 @@ class Test_WP_Customize_Post_Setting extends WP_UnitTestCase {
 	 *
 	 * @see WP_Customize_Post_Setting::__construct()
 	 */
-	public function test_construct_unprivileged_user() {
+	public function test_construct_capability() {
 		$exception = null;
 		$post = get_post( $this->factory()->post->create() );
 		$setting_id = sprintf( 'post[%s][%d]', $post->post_type, $post->ID );
 		wp_set_current_user( 0 );
 		$setting = new WP_Customize_Post_Setting( $this->wp_customize, $setting_id );
 		$this->assertFalse( current_user_can( $setting->capability ) );
-		$this->assertEquals( 'do_not_allow', $setting->capability );
-	}
+		$this->assertEquals( sprintf( 'edit_post[%d]', $post->ID ), $setting->capability );
 
-	/**
-	 * Test __construct().
-	 *
-	 * @see WP_Customize_Post_Setting::__construct()
-	 */
-	public function test_construct_insert() {
-		$exception = null;
-		$setting_id = sprintf( 'post[%s][%d]', 'post', -123 );
-		$setting = new WP_Customize_Post_Setting( $this->wp_customize, $setting_id );
-
-		$this->assertEquals( 'edit_posts', $setting->capability );
-		wp_set_current_user( 0 );
-
-		$setting = new WP_Customize_Post_Setting( $this->wp_customize, $setting_id );
-		$this->assertEquals( 'do_not_allow', $setting->capability );
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'editor' ) ) );
+		$this->assertTrue( current_user_can( $setting->capability ) );
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-postmeta-setting.php
+++ b/tests/php/test-class-wp-customize-postmeta-setting.php
@@ -128,7 +128,7 @@ class Test_Customize_Postmeta_Setting extends WP_UnitTestCase {
 	/**
 	 * @see WP_Customize_Postmeta_Setting::__construct()
 	 */
-	function test_construct_for_unprivileged_user() {
+	function test_construct_capability() {
 		$subscriber_id = $this->factory()->user->create( array( 'role' => 'subscriber' ) );
 		$post_id = $this->factory()->post->create( array( 'post_type' => 'post') );
 		wp_set_current_user( $subscriber_id );
@@ -136,8 +136,11 @@ class Test_Customize_Postmeta_Setting extends WP_UnitTestCase {
 		$setting_id = sprintf( 'postmeta[post][%d][%s]', $post_id, $meta_key );
 		register_meta( 'post', $meta_key, 'sanitize_email' );
 		$setting = new WP_Customize_Postmeta_Setting( $this->manager, $setting_id );
-		$this->assertEquals( 'do_not_allow', $setting->capability );
+		$this->assertEquals( sprintf( 'edit_post_meta[%d][%s]', $post_id, $meta_key ), $setting->capability );
 		$this->assertFalse( current_user_can( $setting->capability ) );
+
+		wp_set_current_user( $this->factory()->user->create( array( 'role' => 'editor' ) ) );
+		$this->assertTrue( current_user_can( $setting->capability ) );
 	}
 
 	/**
@@ -192,9 +195,8 @@ class Test_Customize_Postmeta_Setting extends WP_UnitTestCase {
 		$this->assertEquals( $meta_key, $setting->meta_key );
 		$this->assertEquals( '', $setting->default );
 		$this->assertTrue( $setting->single );
-		$this->assertEquals( 'edit_posts', $setting->capability );
+		$this->assertEquals( sprintf( 'edit_post_meta[%d][%s]', $post_id, $meta_key ), $setting->capability );
 		$this->assertInstanceOf( 'WP_Customize_Posts', $setting->posts_component );
-		$this->assertEquals( 'edit_posts', $setting->capability );
 
 		$setting = new WP_Customize_Postmeta_Setting( $this->manager, $setting_id, array(
 			'capability' => 'create_awesome',
@@ -208,7 +210,7 @@ class Test_Customize_Postmeta_Setting extends WP_UnitTestCase {
 		$setting = new WP_Customize_Postmeta_Setting( $this->manager, $setting_id, array(
 			'capability' => 'delete_awesome',
 		) );
-		$this->assertEquals( 'do_not_allow', $setting->capability );
+		$this->assertEquals( 'delete_awesome', $setting->capability );
 		remove_filter( 'user_has_cap', '__return_empty_array' );
 	}
 


### PR DESCRIPTION
Use dynamic capabilities that include the params embedded as keys, and then map the meta cap just in time.

See https://core.trac.wordpress.org/ticket/38672