### PR TITLE
Pass missing options param in wrapped isLinkPrewable function

### DIFF
--- a/js/customize-preview-posts.js
+++ b/js/customize-preview-posts.js
@@ -143,11 +143,11 @@
 
 		// Prevent not-allowed cursor on edit-post-links.
 		api.isLinkPreviewable = ( function( originalIsLinkPreviewable ) {
-			return function( element ) {
+			return function( element, options ) {
 				if ( $( element ).hasClass( 'post-edit-link' ) ) {
 					return true;
 				}
-				return originalIsLinkPreviewable.call( this, element );
+				return originalIsLinkPreviewable.call( this, element, options );
 			};
 		} )( api.isLinkPreviewable );
 	}


### PR DESCRIPTION
This was causing admin-ajax requests on the frontend from failing to get the customized state injected since the `allowAdminAjax` param was not passed.