### PR TITLE
Improve compat with posts & pages created as stubs in 4.7

### DIFF
--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -1402,6 +1402,14 @@ final class WP_Customize_Posts_Preview {
 			}
 		}
 
+		// Ensure that page/post stubs are included among the queried posts.
+		if ( $this->component->manager->nav_menus && $this->component->manager->get_setting( 'nav_menus_created_posts' ) ) {
+			$this->queried_post_ids = array_merge(
+				$this->queried_post_ids,
+				$this->component->manager->get_setting( 'nav_menus_created_posts' )->value()
+			);
+		}
+
 		$exported = array(
 			'isPostPreview' => is_preview(),
 			'isSingular' => is_singular(),


### PR DESCRIPTION
Ensure that page/post stubs are included among the queried posts so that when the customizer loads these posts/pages their corresponding post sections will be pre-loaded. Also when saving, filter out post IDs from `nav_menus_created_posts` when there are corresponding `post` settings to prevent conflicts between saving the two.