### PR TITLE
Handle edit post links that have child elements; remove need for data-customize-post-id attribute

### DIFF
--- a/js/customize-preview-posts.js
+++ b/js/customize-preview-posts.js
@@ -192,8 +192,12 @@
 			 * Focus on the post section in the Customizer pane when clicking an edit-post-link.
 			 */
 			$( document.body ).on( 'click', '.post-edit-link', function( e ) {
-				var link = $( this ), postId;
-				postId = link.data( 'customize-post-id' );
+				var link = $( this ), postId, matches;
+				matches = link.prop( 'search' ).match( /post=(\d+)/ );
+				if ( ! matches ) {
+					return;
+				}
+				postId = parseInt( matches[1], 10 );
 				e.preventDefault();
 				if ( postId ) {
 					api.preview.send( 'edit-post', postId );

--- a/js/customize-preview-posts.js
+++ b/js/customize-preview-posts.js
@@ -144,7 +144,7 @@
 		// Prevent not-allowed cursor on edit-post-links.
 		api.isLinkPreviewable = ( function( originalIsLinkPreviewable ) {
 			return function( element, options ) {
-				if ( $( element ).hasClass( 'post-edit-link' ) ) {
+				if ( $( element ).closest( 'a' ).hasClass( 'post-edit-link' ) ) {
 					return true;
 				}
 				return originalIsLinkPreviewable.call( this, element, options );
@@ -156,7 +156,7 @@
 	if ( api.Preview.prototype.handleLinkClick ) {
 		api.Preview.prototype.handleLinkClick = ( function( originalHandleLinkClick ) {
 			return function( event ) {
-				if ( $( event.target ).hasClass( 'post-edit-link' ) ) {
+				if ( $( event.target ).closest( 'a' ).hasClass( 'post-edit-link' ) ) {
 					event.preventDefault();
 				} else {
 					originalHandleLinkClick.call( this, event );

--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -94,7 +94,6 @@ final class WP_Customize_Posts_Preview {
 		add_filter( 'the_posts', array( $this, 'filter_the_posts_to_tally_previewed_posts' ), 1000 );
 		add_filter( 'the_posts', array( $this, 'filter_the_posts_to_tally_orderby_keys' ), 10, 2 );
 		add_action( 'wp_footer', array( $this, 'export_preview_data' ), 10 );
-		add_filter( 'edit_post_link', array( $this, 'filter_edit_post_link' ), 10, 2 );
 		add_filter( 'get_edit_post_link', array( $this, 'filter_get_edit_post_link' ), 10, 2 );
 		add_filter( 'get_avatar', array( $this, 'filter_get_avatar' ), 10, 6 );
 		add_filter( 'infinite_scroll_results', array( $this, 'amend_with_queried_post_ids' ) );
@@ -1237,19 +1236,6 @@ final class WP_Customize_Posts_Preview {
 			return null;
 		}
 		return $url;
-	}
-
-	/**
-	 * Filter the post edit link so it can open the post in the Customizer.
-	 *
-	 * @param string $link    Anchor tag for the edit link.
-	 * @param int    $post_id Post ID.
-	 * @return string Edit link.
-	 */
-	function filter_edit_post_link( $link, $post_id ) {
-		$data_attributes = sprintf( ' data-customize-post-id="%d"', $post_id );
-		$link = preg_replace( '/(?<=<a\s)/', $data_attributes, $link );
-		return $link;
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-posts-preview.php
+++ b/tests/php/test-class-wp-customize-posts-preview.php
@@ -127,7 +127,6 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 		$this->assertEquals( 1000, has_filter( 'the_posts', array( $preview, 'filter_the_posts_to_tally_previewed_posts' ) ) );
 		$this->assertEquals( 10, has_filter( 'the_posts', array( $preview, 'filter_the_posts_to_tally_orderby_keys' ) ) );
 		$this->assertEquals( 10, has_action( 'wp_footer', array( $preview, 'export_preview_data' ) ) );
-		$this->assertEquals( 10, has_filter( 'edit_post_link', array( $preview, 'filter_edit_post_link' ) ) );
 		$this->assertEquals( 10, has_filter( 'get_edit_post_link', array( $preview, 'filter_get_edit_post_link' ) ) );
 		$this->assertEquals( 10, has_filter( 'get_avatar', array( $preview, 'filter_get_avatar' ) ) );
 		$this->assertEquals( 10, has_filter( 'infinite_scroll_results', array( $preview, 'amend_with_queried_post_ids' ) ) );
@@ -1153,18 +1152,6 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 
 		wp_set_current_user( $this->user_id );
 		$this->assertEquals( $edit_post_link, $preview->filter_get_edit_post_link( $edit_post_link, $this->post_id ) );
-	}
-
-	/**
-	 * Test filter_edit_post_link().
-	 *
-	 * @see WP_Customize_Posts_Preview::filter_edit_post_link()
-	 */
-	public function test_filter_edit_post_link() {
-		$preview = new WP_Customize_Posts_Preview( $this->posts_component );
-		$link = '<a class="edit-me" href="' . esc_url( home_url( '?edit-me' ) ) . '">Edit</a>';
-		$contained = sprintf( ' data-customize-post-id="%d"', $this->post_id );
-		$this->assertContains( $contained, $preview->filter_edit_post_link( $link, $this->post_id ) );
 	}
 
 	/**


### PR DESCRIPTION
See [#39098](https://core.trac.wordpress.org/ticket/39098) (Customize: Clicking on child elements of preview links fails to abort navigation to non-previewable links)