### PR TITLE
Improve logic for determining when to do fallback refresh for post field partials

### DIFF
--- a/php/class-wp-customize-featured-image-controller.php
+++ b/php/class-wp-customize-featured-image-controller.php
@@ -26,6 +26,13 @@ class WP_Customize_Featured_Image_Controller extends WP_Customize_Postmeta_Contr
 	const SELECTED_ATTRIBUTE = 'data-customize-featured-image-partial';
 
 	/**
+	 * Selector for finding featured images.
+	 *
+	 * @var string
+	 */
+	const SELECTOR = '[data-customize-featured-image-partial="%d"]';
+
+	/**
 	 * The container_inclusive param for the partials.
 	 *
 	 * @var string
@@ -117,9 +124,14 @@ class WP_Customize_Featured_Image_Controller extends WP_Customize_Postmeta_Contr
 	public function enqueue_customize_preview_scripts() {
 		$handle = 'customize-preview-featured-image';
 		wp_enqueue_script( $handle );
+
+		// @todo These arguments should be configurable for featured image partials just as they are for post field partials.
 		$exports = array(
-			'partialSelectorAttribute' => self::SELECTED_ATTRIBUTE,
-			'partialContainerInclusive' => self::PARTIAL_CONTAINER_INCLUSIVE,
+			'partialArgs' => array(
+				'selector' => self::SELECTOR,
+				'fallbackDependentSelector' => '.hentry.post-%d, body.page-id-%d, body.postid-%d',
+				'containerInclusive' => self::PARTIAL_CONTAINER_INCLUSIVE,
+			),
 		);
 		wp_add_inline_script( $handle, sprintf( 'CustomizePreviewFeaturedImage.init( %s )', wp_json_encode( $exports ) ) );
 	}
@@ -281,7 +293,7 @@ class WP_Customize_Featured_Image_Controller extends WP_Customize_Postmeta_Contr
 			$partial_args['settings'] = array( $setting_id );
 			$partial_args['primary_setting'] = $setting_id;
 			$partial_args['type'] = 'featured_image';
-			$partial_args['selector'] = '[' . self::SELECTED_ATTRIBUTE . '=' . $matches['post_id'] . ']';
+			$partial_args['selector'] = sprintf( self::SELECTOR, $matches['post_id'] );
 			$partial_args['container_inclusive'] = self::PARTIAL_CONTAINER_INCLUSIVE;
 		}
 		return $partial_args;

--- a/php/theme-support/class-customize-posts-twenty-eleven-support.php
+++ b/php/theme-support/class-customize-posts-twenty-eleven-support.php
@@ -43,7 +43,7 @@ class Customize_Posts_Twenty_Eleven_Support extends Customize_Posts_Theme_Suppor
 
 		$schema['post_author[biography]'] = array(
 			'selector' => '#author-info',
-			'singular_only' => true,
+			'fallback_dependent_selector' => 'body.singular',
 			'container_inclusive' => true,
 			'render_callback' => array( $this, 'biography_render_callback' ),
 		);

--- a/php/theme-support/class-customize-posts-twenty-fifteen-support.php
+++ b/php/theme-support/class-customize-posts-twenty-fifteen-support.php
@@ -41,7 +41,7 @@ class Customize_Posts_Twenty_Fifteen_Support extends Customize_Posts_Theme_Suppo
 	public function filter_partial_schema( $schema ) {
 		$schema['post_author[biography]'] = array(
 			'selector' => '.author-info',
-			'singular_only' => true,
+			'fallback_dependent_selector' => 'body.singular',
 			'container_inclusive' => true,
 			'render_callback' => array( $this, 'biography_render_callback' ),
 		);

--- a/php/theme-support/class-customize-posts-twenty-seventeen-support.php
+++ b/php/theme-support/class-customize-posts-twenty-seventeen-support.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Customize Posts Twenty Seventeen Support.
+ *
+ * @package WordPress
+ * @subpackage Customize
+ */
+
+/**
+ * Class Customize_Posts_Twenty_Seventeen_Support
+ *
+ * @codeCoverageIgnore
+ */
+class Customize_Posts_Twenty_Seventeen_Support extends Customize_Posts_Theme_Support {
+
+	/**
+	 * Theme slug.
+	 *
+	 * @access public
+	 * @var string
+	 */
+	public $slug = 'twentyseventeen';
+
+	/**
+	 * Add theme support.
+	 *
+	 * @access public
+	 */
+	public function add_support() {
+		add_filter( 'customize_posts_partial_schema', array( $this, 'filter_partial_schema' ) );
+	}
+
+	/**
+	 * Filter partial schema.
+	 *
+	 * @access public
+	 *
+	 * @param array $schema Partial schema.
+	 * @return array
+	 */
+	public function filter_partial_schema( $schema ) {
+		$schema['post_excerpt']['fallback_refresh'] = false; // Not needed because there are no has_excerpt() checks in the theme.
+		return $schema;
+	}
+}

--- a/php/theme-support/class-customize-posts-twenty-sixteen-support.php
+++ b/php/theme-support/class-customize-posts-twenty-sixteen-support.php
@@ -41,7 +41,7 @@ class Customize_Posts_Twenty_Sixteen_Support extends Customize_Posts_Theme_Suppo
 	public function filter_partial_schema( $schema ) {
 		$schema['post_author[biography]'] = array(
 			'selector' => '.author-info',
-			'singular_only' => true,
+			'fallback_dependent_selector' => 'body.singular',
 			'container_inclusive' => true,
 			'render_callback' => array( $this, 'biography_render_callback' ),
 		);

--- a/php/theme-support/class-customize-posts-twenty-ten-support.php
+++ b/php/theme-support/class-customize-posts-twenty-ten-support.php
@@ -45,7 +45,7 @@ class Customize_Posts_Twenty_Ten_Support extends Customize_Posts_Theme_Support {
 
 		$schema['post_author[biography]'] = array(
 			'selector' => '#entry-author-info',
-			'singular_only' => true,
+			'fallback_dependent_selector' => 'body.singular',
 			'container_inclusive' => true,
 			'render_callback' => array( $this, 'biography_render_callback' ),
 		);

--- a/php/theme-support/class-customize-posts-twenty-thirteen-support.php
+++ b/php/theme-support/class-customize-posts-twenty-thirteen-support.php
@@ -41,7 +41,7 @@ class Customize_Posts_Twenty_Thirteen_Support extends Customize_Posts_Theme_Supp
 	public function filter_partial_schema( $schema ) {
 		$schema['post_author[biography]'] = array(
 			'selector' => '.author-info',
-			'singular_only' => true,
+			'fallback_dependent_selector' => 'body.singular',
 			'container_inclusive' => true,
 			'render_callback' => array( $this, 'biography_render_callback' ),
 		);

--- a/php/theme-support/class-customize-posts-twenty-twelve-support.php
+++ b/php/theme-support/class-customize-posts-twenty-twelve-support.php
@@ -41,7 +41,7 @@ class Customize_Posts_Twenty_Twelve_Support extends Customize_Posts_Theme_Suppor
 	public function filter_partial_schema( $schema ) {
 		$schema['post_author[biography]'] = array(
 			'selector' => '.author-info',
-			'singular_only' => true,
+			'fallback_dependent_selector' => 'body.singular',
 			'container_inclusive' => true,
 			'render_callback' => array( $this, 'biography_render_callback' ),
 		);

--- a/tests/data/themes/dummy/functions.php
+++ b/tests/data/themes/dummy/functions.php
@@ -58,7 +58,7 @@ if ( ! class_exists( 'Customize_Posts_Dummy_Support' ) ) {
 		public function filter_partial_schema( $schema ) {
 			$schema['post_author[biography]'] = array(
 				'selector' => '.author-info',
-				'singular_only' => true,
+				'fallback_dependent_selector' => 'body.singular',
 				'container_inclusive' => true,
 				'render_callback' => array( $this, 'biography_render_callback' ),
 			);


### PR DESCRIPTION
The changes are part of some experimentation I'm doing (along with JS Widgets) to enable Customize Posts to directly mutate Backbone models created from the WP-API JS client, with the aim of demonstrating patterns for how Customize Posts can be used to manage themes that are rendered purely with JS templates. As part of this I found that we need the partials to be smarter about when they decide that they need to do the fallback behavior of a full refresh. I've introduced the idea of a “fallback dependent selector” which is used to do a test on the document to see whether or not a refresh is warranted. Namely, this selector is intended to normally match the body class or post class that would reference a given post so that if neither the current singular preview or the current archive loop mention a given post, then the fallback refresh behavior should be skipped because the element wouldn't be appearing on the page anyway. As such, this should cut down on some needless full refreshes.

* Refactor body_selector, singular_only, and archive_only into fallback_dependent_selector
* Allows partial selectors to have make use of post ID placeholders in the form of %d.
* Selective refresh fallback behavior is changed to be prevented when changing a post that isn't referenced on a given template (via body_class or post_class).
* Nevertheless, the selective refresh requests still are made so that the REST API Backbone models have the opportunity to update their rendered properties.
* Adds initial support for Twenty Seventeen.