### PR TITLE
Update plugin description to remove reference to obsolete feature plugin

### DIFF
--- a/customize-posts.php
+++ b/customize-posts.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Customize Posts
- * Description: Manage posts and postmeta via the Customizer. Works best in conjunction with the <a href="https://wordpress.org/plugins/customize-setting-validation/">Customize Setting Validation</a> plugin.
+ * Description: Manage posts and postmeta via the Customizer.
  * Plugin URI: https://github.com/xwp/wp-customize-posts/
  * Version: 0.8.5
  * Author: XWP


### PR DESCRIPTION
Removing reference to the now obsolete Customize Setting Validation plugin.

Fixes #323.