### PR TITLE
Use auto-draft with late future date instead of customize-draft and clean auto-draft on changeset delete.

### DIFF
--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -434,7 +434,7 @@ class Customize_Posts_Plugin {
 				}
 
 				// Confirm that this changeset is the only one which references this post so it is cleared for garbage collection.
-				$query = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = %s AND post_status NOT IN ('trash', 'publish') AND ID != %d AND ", $post->post_type, $post->ID );
+				$query = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = %s AND ID != %d AND ", $post->post_type, $post->ID );
 				$query .= $wpdb->prepare( 'post_content LIKE %s', '%' . $wpdb->esc_like( wp_json_encode( $setting_key ) ) . '%' );
 				$query .= ' LIMIT 1';
 				if ( $wpdb->get_var( $query ) ) { // WPCS: unprepared SQL ok.

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -70,7 +70,7 @@ class Customize_Posts_Plugin {
 		add_filter( 'customize_loaded_components', array( $this, 'add_posts_to_customize_loaded_components' ), 0, 1 );
 		add_filter( 'customize_loaded_components', array( $this, 'filter_customize_loaded_components' ), 100, 2 );
 		add_action( 'customize_register', array( $this, 'load_support_classes' ) );
-		add_action( 'delete_post', array( $this, 'delete_changeset_created_posts' ) );
+		add_action( 'delete_post', array( $this, 'cleanup_autodraft_on_changeset_delete' ) );
 	}
 
 	/**
@@ -413,10 +413,9 @@ class Customize_Posts_Plugin {
 	/**
 	 * Delete auto-draft posts associated with the supplied changeset.
 	 *
-	 * @action delete_post
 	 * @param int $post_id changeset/snapshot post_id.
 	 */
-	public function delete_changeset_created_posts( $post_id ) {
+	public function cleanup_autodraft_on_changeset_delete( $post_id ) {
 		global $wpdb;
 		$post = get_post( $post_id );
 		$allowed_snapshot_status = array( 'customize_changeset', 'customize_snapshot' );

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -434,7 +434,7 @@ class Customize_Posts_Plugin {
 				}
 
 				// Confirm that this changeset is the only one which references this post so it is cleared for garbage collection.
-				$query = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = %s AND post_status NOT IN ('trash', 'publish') AND ID != %d AND ", $setting_post->post_status, $setting_post->ID );
+				$query = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = %s AND post_status NOT IN ('trash', 'publish') AND ID != %d AND ", $post->post_type, $post->ID );
 				$query .= $wpdb->prepare( 'post_content LIKE %s', '%' . $wpdb->esc_like( wp_json_encode( $setting_key ) ) . '%' );
 				$query .= ' LIMIT 1';
 				if ( $wpdb->get_var( $query ) ) { // WPCS: unprepared SQL ok.

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -440,7 +440,7 @@ class Customize_Posts_Plugin {
 				if ( $wpdb->get_var( $query ) ) { // WPCS: unprepared SQL ok.
 					continue;
 				}
-				wp_delete_post( $setting_post->ID );
+				wp_delete_post( $setting_post->ID, true );
 			}
 		}
 	}

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -418,8 +418,8 @@ class Customize_Posts_Plugin {
 	public function cleanup_autodraft_on_changeset_delete( $post_id ) {
 		global $wpdb;
 		$post = get_post( $post_id );
-		$allowed_snapshot_status = array( 'customize_changeset', 'customize_snapshot' );
-		if ( ! $post || ! in_array( $post->post_type, $allowed_snapshot_status, true ) ) {
+		$allowed_snapshot_post_type = array( 'customize_changeset', 'customize_snapshot' );
+		if ( ! $post || ! in_array( $post->post_type, $allowed_snapshot_post_type, true ) ) {
 			return;
 		}
 		require_once( ABSPATH . WPINC . '/class-wp-customize-setting.php' );
@@ -429,11 +429,11 @@ class Customize_Posts_Plugin {
 		foreach ( $settings_data as $setting_key => $val ) {
 			if ( preg_match( WP_Customize_Post_Setting::SETTING_ID_PATTERN, $setting_key, $matches ) ) {
 				$setting_post = get_post( $matches['post_id'] );
-				if ( ! in_array( $setting_post->post_status, $status_to_delete, true ) ) {
+				if ( ! ( $setting_post instanceof WP_Post ) || ! in_array( $setting_post->post_status, $status_to_delete, true ) ) {
 					continue;
 				}
 
-				// Confirm this is the only post setting.
+				// Confirm that this changeset is the only one which references this post so it is cleared for garbage collection.
 				$query = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = %s AND post_status NOT IN ('trash', 'publish') AND ID != %d AND ", $setting_post->post_status, $setting_post->ID );
 				$query .= $wpdb->prepare( 'post_content LIKE %s', '%' . $wpdb->esc_like( wp_json_encode( $setting_key ) ) . '%' );
 				$query .= ' LIMIT 1';

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -1086,12 +1086,13 @@ final class WP_Customize_Posts {
 			return;
 		}
 
-		// Short-circuit if the auto-draft posts should be left intact or they would be getting published.
-		if ( 'auto-draft' === $new_status || 'publish' === $new_status ) {
+		// Short-circuit if getting published.
+		if ( 'publish' === $new_status ) {
 			return;
 		}
 
 		$auto_draft_posts = array();
+		$allowed_status = array( 'auto-draft', 'customize-draft' );
 		$data = json_decode( $post->post_content, true );
 		if ( ! is_array( $data ) ) {
 			return;
@@ -1102,7 +1103,7 @@ final class WP_Customize_Posts {
 				continue;
 			}
 			$post = get_post( $matches['post_id'] );
-			if ( 'auto-draft' === $post->post_status ) {
+			if ( in_array( $post->post_status, $allowed_status, true ) ) {
 				$auto_draft_posts[] = $post;
 			}
 		}
@@ -1110,23 +1111,47 @@ final class WP_Customize_Posts {
 		if ( isset( $data['nav_menus_created_posts']['value'] ) && is_array( $data['nav_menus_created_posts']['value'] ) ) {
 			foreach ( $data['nav_menus_created_posts']['value'] as $post_id ) {
 				$post = get_post( $post_id );
-				if ( $post && 'auto-draft' === $post->post_status ) {
+				if ( $post && in_array( $post->post_status, $allowed_status, true ) ) {
 					$auto_draft_posts[] = $post;
 				}
 			}
 		}
 
-		$new_status = 'customize-draft';
+		if ( 'auto-draft' === $new_status ) {
+			/*
+			 * Keep the post date for the post matching the changeset
+			 * so that it will not be garbage-collected before the changeset.
+			 */
+			$new_post_date = $post->post_date;
+		} else {
+			/*
+			 * Since the changeset no longer has an auto-draft (and it is not published)
+			 * it is now a persistent changeset, a long-lived draft, and so any
+			 * associated auto-draft posts should have their dates
+			 * pushed out very far into the future to prevent them from ever
+			 * being garbage-collected.
+			 */
+			$new_post_date = gmdate( 'Y-m-d H:i:d', strtotime( '+100 years' ) );
+		}
+
 		foreach ( $auto_draft_posts as $post ) {
-			$wpdb->update(
-				$wpdb->posts,
-				array( 'post_status' => $new_status ),
-				array( 'ID' => $post->ID )
+			$update_data = array(
+				'post_date' => $new_post_date,
 			);
+
+			// Allows old post status `customize-draft` to change into auto-draft.
+			if ( 'customize-draft' === $post->post_status ) {
+				$update_data['post_status'] = 'auto-draft';
+			}
+			$wpdb->update( $wpdb->posts, $update_data, array(
+				'ID' => $post->ID,
+			) );
 			clean_post_cache( $post->ID );
 
-			// Fires actions related to the transitioning of a post's status.
-			wp_transition_post_status( $new_status, $post->post_status, $post );
+			if ( isset( $update_data['post_status'] ) ) {
+				// Fires actions related to the transitioning of a post's status.
+				wp_transition_post_status( $update_data['post_status'], $post->post_status, $post );
+			}
 		}
 	}
 
@@ -1178,7 +1203,7 @@ final class WP_Customize_Posts {
 					continue;
 				}
 				$post_id = intval( $matches['post_id'] );
-				if ( 'customize-draft' === get_post_status( $post_id ) ) {
+				if ( 'auto-draft' === get_post_status( $post_id ) ) {
 					$this->customize_draft_post_ids[] = $post_id;
 				}
 			}
@@ -1186,7 +1211,7 @@ final class WP_Customize_Posts {
 	}
 
 	/**
-	 * Allow the `customize-draft` status to be previewed in a Snapshot by all users.
+	 * Allow the `auto-draft` status to be previewed in a Snapshot by all users.
 	 *
 	 * @action pre_get_posts
 	 * @access public
@@ -1205,7 +1230,7 @@ final class WP_Customize_Posts {
 			}
 
 			if ( in_array( $post_id, $this->customize_draft_post_ids, true ) ) {
-				$query->set( 'post_status', 'customize-draft' );
+				$query->set( 'post_status', 'auto-draft' );
 			}
 		}
 	}

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -1102,17 +1102,17 @@ final class WP_Customize_Posts {
 			if ( ! preg_match( WP_Customize_Post_Setting::SETTING_ID_PATTERN, $id, $matches ) ) {
 				continue;
 			}
-			$post = get_post( $matches['post_id'] );
-			if ( in_array( $post->post_status, $allowed_status, true ) ) {
-				$auto_draft_posts[] = $post;
+			$setting_post = get_post( $matches['post_id'] );
+			if ( $setting_post instanceof WP_Post && in_array( $setting_post->post_status, $allowed_status, true ) ) {
+				$auto_draft_posts[] = $setting_post;
 			}
 		}
 
 		if ( isset( $data['nav_menus_created_posts']['value'] ) && is_array( $data['nav_menus_created_posts']['value'] ) ) {
 			foreach ( $data['nav_menus_created_posts']['value'] as $post_id ) {
-				$post = get_post( $post_id );
-				if ( $post && in_array( $post->post_status, $allowed_status, true ) ) {
-					$auto_draft_posts[] = $post;
+				$setting_post = get_post( $post_id );
+				if ( $setting_post instanceof WP_Post && in_array( $setting_post->post_status, $allowed_status, true ) ) {
+					$auto_draft_posts[] = $setting_post;
 				}
 			}
 		}

--- a/tests/php/test-class-customize-posts-plugin.php
+++ b/tests/php/test-class-customize-posts-plugin.php
@@ -235,7 +235,7 @@ class Test_Customize_Posts_Plugin extends WP_UnitTestCase {
 			'post_content' => wp_json_encode( $data ),
 		) ) );
 		$changeset_post = get_post( $changeset_post_id );
-		$this->assertInstanceOf( WP_Post::class, get_post( $auto_draft_post_id ) );
+		$this->assertInstanceOf( 'WP_Post', get_post( $auto_draft_post_id ) );
 		wp_delete_post( $changeset_post->ID, true );
 		$this->assertNull( get_post( $auto_draft_post_id ) );
 		$this->wp_customize = null;

--- a/tests/php/test-class-customize-posts-plugin.php
+++ b/tests/php/test-class-customize-posts-plugin.php
@@ -199,4 +199,45 @@ class Test_Customize_Posts_Plugin extends WP_UnitTestCase {
 		$this->assertTrue( wp_style_is( 'customize-posts', 'registered' ) );
 		$this->assertTrue( wp_style_is( 'edit-post-preview-customize', 'registered' ) );
 	}
+
+	/**
+	 * Test on delete changeset all auto-draft posts created with it is deleted.
+	 *
+	 * @see Customize_Posts_Plugin::cleanup_autodraft_on_changeset_delete()
+	 */
+	function test_cleanup_autodraft_on_changeset_delete() {
+		$this->assertEquals( 10, has_action( 'delete_post', array(
+			$this->plugin,
+			'cleanup_autodraft_on_changeset_delete',
+		) ) );
+		require_once( ABSPATH . WPINC . '/class-wp-customize-manager.php' );
+		// @codingStandardsIgnoreStart
+		$GLOBALS['wp_customize'] = new WP_Customize_Manager();
+		// @codingStandardsIgnoreStop
+		$wp_customize = $GLOBALS['wp_customize'];
+		if ( isset( $wp_customize->posts ) ) {
+			$posts = $wp_customize->posts;
+		}
+		$auto_draft_post = $posts->insert_auto_draft_post( 'post' );
+		$auto_draft_post_id = $auto_draft_post->ID;
+		$post_setting_id = WP_Customize_Post_Setting::get_post_setting_id( $auto_draft_post );
+		unset( $auto_draft_post );
+		$data = array();
+		$data[ $post_setting_id ] = array(
+			'value' => array(
+				'post_title' => 'Testing Post Publish',
+				'post_status' => 'publish',
+			),
+		);
+		$changeset_post_id = wp_insert_post( wp_slash( array(
+			'post_type' => 'customize_changeset',
+			'post_status' => 'auto-draft',
+			'post_content' => wp_json_encode( $data ),
+		) ) );
+		$changeset_post = get_post( $changeset_post_id );
+		$this->assertInstanceOf( WP_Post::class, get_post( $auto_draft_post_id ) );
+		wp_delete_post( $changeset_post->ID, true );
+		$this->assertNull( get_post( $auto_draft_post_id ) );
+		$this->wp_customize = null;
+	}
 }

--- a/tests/php/test-class-customize-posts-plugin.php
+++ b/tests/php/test-class-customize-posts-plugin.php
@@ -234,9 +234,18 @@ class Test_Customize_Posts_Plugin extends WP_UnitTestCase {
 			'post_status' => 'auto-draft',
 			'post_content' => wp_json_encode( $data ),
 		) ) );
-		$changeset_post = get_post( $changeset_post_id );
+		// Duplicate post.
+		$changeset_post_id_duplicate = wp_insert_post( wp_slash( array(
+			'post_type' => 'customize_changeset',
+			'post_status' => 'auto-draft',
+			'post_content' => wp_json_encode( $data ),
+		) ) );
 		$this->assertInstanceOf( 'WP_Post', get_post( $auto_draft_post_id ) );
-		wp_delete_post( $changeset_post->ID, true );
+		wp_delete_post( $changeset_post_id, true );
+		// Should not delete as duplicate post exists.
+		$this->assertInstanceOf( 'WP_Post', get_post( $auto_draft_post_id ) );
+		wp_delete_post( $changeset_post_id_duplicate, true );
+		// Should delete as there are no other ref of setting draft post.
 		$this->assertNull( get_post( $auto_draft_post_id ) );
 		$this->wp_customize = null;
 	}

--- a/tests/php/test-class-wp-customize-posts-preview.php
+++ b/tests/php/test-class-wp-customize-posts-preview.php
@@ -281,7 +281,6 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 	 * Test filter_the_posts_to_preview_settings().
 	 *
 	 * @covers WP_Customize_Posts_Preview::filter_the_posts_to_preview_settings()
-	 * @covers WP_Customize_Posts_Preview::compare_posts_to_resort_posts_for_query()
 	 */
 	public function test_filter_the_posts_to_preview_settings() {
 		$data = array(

--- a/tests/php/test-class-wp-customize-posts.php
+++ b/tests/php/test-class-wp-customize-posts.php
@@ -551,29 +551,28 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 		$changeset_post_id = wp_insert_post( wp_slash( array(
 			'post_type' => 'customize_changeset',
 			'post_status' => 'auto-draft',
-			'post_content' => wp_json_encode( $data )
+			'post_content' => wp_json_encode( $data ),
 		) ) );
 
+		$changeset_post = get_post( $changeset_post_id );
 		$this->assertEquals( 'auto-draft', get_post_status( $auto_draft_post->ID ) );
+		$this->assertEquals( $changeset_post->post_date, get_post_field( 'post_date', $auto_draft_post->ID, 'raw' ) );
 		$this->assertEquals( 'auto-draft', get_post_status( $auto_draft_page->ID ) );
+		$this->assertEquals( $changeset_post->post_date, get_post_field( 'post_date', $auto_draft_page->ID, 'raw' ) );
 		$this->assertEquals( 'auto-draft', get_post_status( $nav_menu_created_stub_post->ID ) );
+		$this->assertEquals( $changeset_post->post_date, get_post_field( 'post_date', $nav_menu_created_stub_post->ID, 'raw' ) );
 
-		$old_status = 'auto-draft';
-		$new_status = 'customize-draft';
 		$count = did_action( 'transition_post_status' );
-		$count_status_change = did_action( "{$old_status}_to_{$new_status}" );
-		$count_post_status = did_action( "{$new_status}_post" );
-		$count_page_status = did_action( "{$new_status}_page" );
 		wp_update_post( array( 'ID' => $changeset_post_id, 'post_status' => 'draft' ) );
-		$this->assertEquals( $count + 4, did_action( 'transition_post_status' ) );
-		$this->assertEquals( $count_status_change + 3, did_action( "{$old_status}_to_{$new_status}" ) );
-		$this->assertEquals( $count_post_status + 2, did_action( "{$new_status}_post" ) );
-		$this->assertEquals( $count_page_status + 1, did_action( "{$new_status}_page" ) );
-
-		$this->assertEquals( 'customize-draft', get_post_status( $auto_draft_post->ID ) );
-		$this->assertEquals( 'customize-draft', get_post_status( $auto_draft_page->ID ) );
-		$this->assertEquals( 'customize-draft', get_post_status( $nav_menu_created_stub_post->ID ) );
-
+		$this->assertEquals( $count + 1, did_action( 'transition_post_status' ) );
+		$new_status = 'auto-draft';
+		$this->assertEquals( $new_status, get_post_status( $auto_draft_post->ID ) );
+		$this->assertEquals( $new_status, get_post_status( $auto_draft_page->ID ) );
+		$this->assertEquals( $new_status, get_post_status( $nav_menu_created_stub_post->ID ) );
+		$expected_year = date('Y') + 100;
+		$this->assertEquals( $expected_year, date( 'Y', strtotime( get_post( $auto_draft_post->ID )->post_date ) ) );
+		$this->assertEquals( $expected_year, date( 'Y', strtotime( get_post( $auto_draft_page->ID )->post_date ) ) );
+		$this->assertEquals( $expected_year, date( 'Y', strtotime( get_post( $nav_menu_created_stub_post->ID )->post_date ) ) );
 		wp_update_post( array( 'ID' => $changeset_post_id, 'post_status' => 'publish' ) );
 		$this->assertEquals( 'publish', get_post_status( $auto_draft_post->ID ) );
 		$this->assertEquals( 'draft', get_post_status( $auto_draft_page->ID ) );
@@ -602,7 +601,7 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 		$this->posts->preview_customize_draft_post_ids();
 		$this->assertEmpty( $this->posts->customize_draft_post_ids );
 
-		wp_update_post( array( 'ID' => $post_id, 'post_status' => 'customize-draft' ) );
+		wp_update_post( array( 'ID' => $post_id, 'post_status' => 'auto-draft' ) );
 		$this->posts->manager->set_post_value( $setting_id, array_merge(
 			$setting->value(),
 			array(
@@ -663,7 +662,7 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 		$this->assertEquals( 'true', $GLOBALS['wp_query']->query_vars['preview'] );
 		$this->assertEquals( $post->ID, $GLOBALS['wp_query']->query_vars['p'] );
 		$this->assertArrayHasKey( 'post_status', $GLOBALS['wp_query']->query_vars );
-		$this->assertEquals( 'customize-draft', $GLOBALS['wp_query']->query_vars['post_status'] );
+		$this->assertEquals( 'auto-draft', $GLOBALS['wp_query']->query_vars['post_status'] );
 	}
 
 	/**

--- a/tests/php/test-class-wp-customize-posts.php
+++ b/tests/php/test-class-wp-customize-posts.php
@@ -551,7 +551,9 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 		$changeset_post_id = wp_insert_post( wp_slash( array(
 			'post_type' => 'customize_changeset',
 			'post_status' => 'auto-draft',
+			'post_date' => gmdate( 'Y-m-d H:i:d', strtotime( '+7 days' ) ),
 			'post_content' => wp_json_encode( $data ),
+			'edit_date' => true,
 		) ) );
 
 		$changeset_post = get_post( $changeset_post_id );
@@ -563,6 +565,7 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 		$this->assertEquals( $changeset_post->post_date, get_post_field( 'post_date', $nav_menu_created_stub_post->ID, 'raw' ) );
 
 		$count = did_action( 'transition_post_status' );
+		$count = post_type_supports( 'customize_changeset', 'revisions' ) ? $count + 1 : $count;
 		wp_update_post( array( 'ID' => $changeset_post_id, 'post_status' => 'draft' ) );
 		$this->assertEquals( $count + 1, did_action( 'transition_post_status' ) );
 		$new_status = 'auto-draft';


### PR DESCRIPTION
Fixes #329 

- [x] Test Use-cases. 
- [x] Write unit-test for Clean up posts on changeset delete.