### PR TITLE
Remove sessionStorage and use changeset to save post editor screen data.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,38 @@
 sudo: false
 
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+cache:
+  directories:
+    - node_modules
+    - vendor
+    - $HOME/phpunit-bin
+
 language:
-    - php
-    - node_js
+  - php
+  - node_js
 
 php:
-    - 5.2
-    - 7.0
+  - 5.3
+  - 7.0
 
 env:
-    - WP_VERSION=4.5 WP_MULTISITE=1
-    - WP_VERSION=latest WP_MULTISITE=0
-    - WP_VERSION=trunk WP_MULTISITE=0
-    - WP_VERSION=trunk WP_MULTISITE=1
+  - WP_VERSION=trunk WP_MULTISITE=0
+  - WP_VERSION=latest WP_MULTISITE=0
+  - WP_VERSION=4.6.1 WP_MULTISITE=0
+  - WP_VERSION=latest WP_MULTISITE=1
 
 install:
-    - nvm install 4 && nvm use 4
-    - export DEV_LIB_PATH=dev-lib
-    - if [ ! -e "$DEV_LIB_PATH" ] && [ -L .travis.yml ]; then export DEV_LIB_PATH=$( dirname $( readlink .travis.yml ) ); fi
-    - if [ ! -e "$DEV_LIB_PATH" ]; then git clone https://github.com/xwp/wp-dev-lib.git $DEV_LIB_PATH; fi
-    - source $DEV_LIB_PATH/travis.install.sh
+  - nvm install 6 && nvm use 6
+  - export DEV_LIB_PATH=dev-lib
+  - if [ ! -e "$DEV_LIB_PATH" ] && [ -L .travis.yml ]; then export DEV_LIB_PATH=$( dirname $( readlink .travis.yml ) ); fi
+  - source $DEV_LIB_PATH/travis.install.sh
 
 script:
-    - source $DEV_LIB_PATH/travis.script.sh
+  - source $DEV_LIB_PATH/travis.script.sh
 
 after_script:
-    - source $DEV_LIB_PATH/travis.after_script.sh
+  - source $DEV_LIB_PATH/travis.after_script.sh

--- a/css/edit-post-preview-admin.css
+++ b/css/edit-post-preview-admin.css
@@ -1,0 +1,3 @@
+#preview-action .spinner:not(.is-active-preview) {
+	visibility: hidden !important;
+}

--- a/css/edit-post-preview-customize.css
+++ b/css/edit-post-preview-customize.css
@@ -3,7 +3,11 @@
 }
 
 #customize-header-actions #save,
-#customize-header-actions #snapshot-save {
+#customize-header-actions #snapshot-save,
+#snapshot-status-button-wrapper,
+#snapshot-preview-link,
+#snapshot-expand-button
+{
 	display: none !important;
 }
 

--- a/js/edit-post-preview-admin.js
+++ b/js/edit-post-preview-admin.js
@@ -1,6 +1,6 @@
 /* global jQuery, _editPostPreviewAdminExports, JSON, tinymce, wp */
 /* exported EditPostPreviewAdmin */
-var EditPostPreviewAdmin = (function( $, api ) {
+var EditPostPreviewAdmin = (function( $ ) {
 	'use strict';
 
 	var component = {
@@ -39,14 +39,14 @@ var EditPostPreviewAdmin = (function( $, api ) {
 			return;
 		}
 
-		api.Loader.link = $btn;
+		wp.customize.Loader.link = $btn;
 
 		// Prevent loader from navigating to new URL.
-		wasMobile = api.Loader.settings.browser.mobile;
-		api.Loader.settings.browser.mobile = false;
+		wasMobile = wp.customize.Loader.settings.browser.mobile;
+		wp.customize.Loader.settings.browser.mobile = false;
 
 		// Override default close behavior.
-		api.Loader.close = component.closeLoader;
+		wp.customize.Loader.close = component.closeLoader;
 
 		parentId = parseInt( $( '#parent_id' ).val(), 10 );
 		if ( ! parentId ) {
@@ -66,34 +66,35 @@ var EditPostPreviewAdmin = (function( $, api ) {
 			post_excerpt: $( '#excerpt' ).val(),
 			comment_status: $( '#comment_status' ).prop( 'checked' ) ? 'open' : 'closed',
 			ping_status: $( '#ping_status' ).prop( 'checked' ) ? 'open' : 'closed',
+			post_status: $( '#post_status' ).val(),
 			post_author: parseInt( $( '#post_author_override' ).val(), 10 )
 		};
 		postSettingId = 'post[' + postType + '][' + postId + ']';
 		settings[ postSettingId ] = postSettingValue;
 
 		// Allow plugins to inject additional settings to preview.
-		api.trigger( 'settings-from-edit-post-screen', settings );
+		wp.customize.trigger( 'settings-from-edit-post-screen', settings );
 
 		// For backward compatibility send the current input fields from the edit post page to the Customizer via sessionStorage.
 		if ( component.data.is_compat ) {
 			sessionStorage.setItem( 'previewedCustomizePostSettings[' + postId + ']', JSON.stringify( settings ) );
-			api.Loader.open( component.data.customize_url );
+			wp.customize.Loader.open( component.data.customize_url );
 			component.bindChangesToCustomizer( postSettingId, editor );
 		} else {
 			request = wp.ajax.post( 'customize_posts_update_changeset', {
 				customize_posts_update_changeset_nonce: component.data.customize_posts_update_changeset_nonce,
 				previewed_post: component.data.previewed_post,
 				customize_url: component.data.customize_url,
-				customize_changeset_data: postSettingValue
+				input_data: postSettingValue
 			} );
 
 			request.done( function( resp ) {
-				api.Loader.open( resp.customize_url );
+				wp.customize.Loader.open( resp.customize_url );
 				component.bindChangesToCustomizer( postSettingId, editor );
 			} );
 		}
 
-		api.Loader.settings.browser.mobile = wasMobile;
+		wp.customize.Loader.settings.browser.mobile = wasMobile;
 	};
 
 	/**
@@ -104,7 +105,7 @@ var EditPostPreviewAdmin = (function( $, api ) {
 	 * @return {void}
 	 */
 	component.bindChangesToCustomizer = function( postSettingId, editor ) {
-		api.Loader.messenger.bind( 'customize-post-settings-data', function( data ) {
+		wp.customize.Loader.messenger.bind( 'customize-post-settings-data', function( data ) {
 			var settingParentId;
 			if ( data[ postSettingId ] ) {
 				$( '#title' ).val( data[ postSettingId ].post_title ).trigger( 'change' );
@@ -112,7 +113,8 @@ var EditPostPreviewAdmin = (function( $, api ) {
 					editor.setContent( wp.editor.autop( data[ postSettingId ].post_content ) );
 				}
 
-				// @todo Handle post_status and post_date sync.
+				// @todo Handle post_date sync.
+				$( '#post_status' ).val( data[ postSettingId ].post_status );
 				$( '#content' ).val( data[ postSettingId ].post_content ).trigger( 'change' );
 				$( '#excerpt' ).val( data[ postSettingId ].post_excerpt ).trigger( 'change' );
 				$( '#comment_status' ).prop( 'checked', 'open' === data[ postSettingId ].comment_status ).trigger( 'change' );
@@ -127,7 +129,7 @@ var EditPostPreviewAdmin = (function( $, api ) {
 			}
 
 			// Let plugins handle updates.
-			api.trigger( 'settings-from-customizer', data );
+			wp.customize.trigger( 'settings-from-customizer', data );
 		} );
 	};
 
@@ -174,4 +176,4 @@ var EditPostPreviewAdmin = (function( $, api ) {
 	};
 
 	return component;
-})( jQuery, wp.customize );
+})( jQuery );

--- a/js/edit-post-preview-admin.js
+++ b/js/edit-post-preview-admin.js
@@ -5,7 +5,8 @@ var EditPostPreviewAdmin = (function( $ ) {
 
 	var component = {
 		data: {
-			customize_url: null
+			customize_url: null,
+			is_compat: false
 		}
 	};
 
@@ -74,7 +75,7 @@ var EditPostPreviewAdmin = (function( $ ) {
 		wp.customize.trigger( 'settings-from-edit-post-screen', settings );
 
 		// For backward compatibility send the current input fields from the edit post page to the Customizer via sessionStorage.
-		if ( component.data.customize_url ) {
+		if ( component.data.is_compat ) {
 			sessionStorage.setItem( 'previewedCustomizePostSettings[' + postId + ']', JSON.stringify( settings ) );
 			component.openCustomizer( component.data.customize_url, postSettingId );
 		} else {
@@ -82,7 +83,6 @@ var EditPostPreviewAdmin = (function( $ ) {
 				customize_posts_update_changeset_nonce: component.data.customize_posts_update_changeset_nonce,
 				previewed_post: component.data.previewed_post,
 				customize_url: component.data.customize_url,
-				post_setting_id: postSettingId,
 				customize_changeset_data: postSettingValue
 			} );
 

--- a/js/edit-post-preview-admin.js
+++ b/js/edit-post-preview-admin.js
@@ -83,6 +83,7 @@ var EditPostPreviewAdmin = (function( $ ) {
 		if ( component.data.is_compat ) {
 			sessionStorage.setItem( 'previewedCustomizePostSettings[' + postId + ']', JSON.stringify( settings ) );
 			wp.customize.Loader.open( component.data.customize_url );
+			wp.customize.Loader.settings.browser.mobile = wasMobile;
 			component.bindChangesFromCustomizer( postSettingId, editor );
 		} else {
 			$btn.addClass( 'disabled' );
@@ -96,6 +97,7 @@ var EditPostPreviewAdmin = (function( $ ) {
 
 			request.done( function( resp ) {
 				wp.customize.Loader.open( resp.customize_url );
+				wp.customize.Loader.settings.browser.mobile = wasMobile;
 				component.bindChangesFromCustomizer( postSettingId, editor );
 			} );
 
@@ -104,8 +106,6 @@ var EditPostPreviewAdmin = (function( $ ) {
 				component.previewButtonSpinner.removeClass( 'is-active' );
 			} );
 		}
-
-		wp.customize.Loader.settings.browser.mobile = wasMobile;
 	};
 
 	/**

--- a/js/edit-post-preview-admin.js
+++ b/js/edit-post-preview-admin.js
@@ -6,7 +6,9 @@ var EditPostPreviewAdmin = (function( $ ) {
 	var component = {
 		data: {
 			customize_url: null,
-			is_compat: false
+			is_compat: false,
+			previewed_post: null,
+			customize_posts_update_changeset_nonce: null
 		}
 	};
 
@@ -81,7 +83,7 @@ var EditPostPreviewAdmin = (function( $ ) {
 		if ( component.data.is_compat ) {
 			sessionStorage.setItem( 'previewedCustomizePostSettings[' + postId + ']', JSON.stringify( settings ) );
 			wp.customize.Loader.open( component.data.customize_url );
-			component.bindChangesToCustomizer( postSettingId, editor );
+			component.bindChangesFromCustomizer( postSettingId, editor );
 		} else {
 			$btn.addClass( 'disabled' );
 			component.previewButtonSpinner.addClass( 'is-active' );
@@ -94,7 +96,7 @@ var EditPostPreviewAdmin = (function( $ ) {
 
 			request.done( function( resp ) {
 				wp.customize.Loader.open( resp.customize_url );
-				component.bindChangesToCustomizer( postSettingId, editor );
+				component.bindChangesFromCustomizer( postSettingId, editor );
 			} );
 
 			request.always( function() {
@@ -113,7 +115,7 @@ var EditPostPreviewAdmin = (function( $ ) {
 	 * @param {object} editor Tinymce object.
 	 * @return {void}
 	 */
-	component.bindChangesToCustomizer = function( postSettingId, editor ) {
+	component.bindChangesFromCustomizer = function( postSettingId, editor ) {
 		wp.customize.Loader.messenger.bind( 'customize-post-settings-data', function( data ) {
 			var settingParentId;
 			if ( data[ postSettingId ] ) {

--- a/js/edit-post-preview-admin.js
+++ b/js/edit-post-preview-admin.js
@@ -1,4 +1,4 @@
-/* global jQuery, _editPostPreviewAdminExports, JSON, tinymce, wp */
+/* global jQuery, _editPostPreviewAdminExports, JSON, tinymce, wp, alert */
 /* exported EditPostPreviewAdmin */
 var EditPostPreviewAdmin = (function( $ ) {
 	'use strict';
@@ -87,12 +87,16 @@ var EditPostPreviewAdmin = (function( $ ) {
 			component.bindChangesFromCustomizer( postSettingId, editor );
 		} else {
 			$btn.addClass( 'disabled' );
-			component.previewButtonSpinner.addClass( 'is-active' );
+			component.previewButtonSpinner.addClass( 'is-active' ).addClass( 'is-active-preview' );
 			request = wp.ajax.post( 'customize_posts_update_changeset', {
 				customize_posts_update_changeset_nonce: component.data.customize_posts_update_changeset_nonce,
 				previewed_post: component.data.previewed_post,
 				customize_url: component.data.customize_url,
 				input_data: postSettingValue
+			} );
+
+			request.fail( function( resp ) {
+				alert( resp ); // eslint-disable-line no-alert
 			} );
 
 			request.done( function( resp ) {
@@ -103,7 +107,7 @@ var EditPostPreviewAdmin = (function( $ ) {
 
 			request.always( function() {
 				$btn.removeClass( 'disabled' );
-				component.previewButtonSpinner.removeClass( 'is-active' );
+				component.previewButtonSpinner.removeClass( 'is-active' ).removeClass( 'is-active-preview' );
 			} );
 		}
 	};

--- a/js/edit-post-preview-admin.js
+++ b/js/edit-post-preview-admin.js
@@ -1,5 +1,7 @@
 /* global jQuery, _editPostPreviewAdminExports, JSON, tinymce, wp, alert */
 /* exported EditPostPreviewAdmin */
+/*eslint no-magic-numbers: ["error", { "ignore": [0, 1] }]*/
+
 var EditPostPreviewAdmin = (function( $ ) {
 	'use strict';
 
@@ -87,7 +89,7 @@ var EditPostPreviewAdmin = (function( $ ) {
 			component.bindChangesFromCustomizer( postSettingId, editor );
 		} else {
 			$btn.addClass( 'disabled' );
-			component.previewButtonSpinner.addClass( 'is-active' ).addClass( 'is-active-preview' );
+			component.previewButtonSpinner.addClass( 'is-active is-active-preview' );
 			request = wp.ajax.post( 'customize_posts_update_changeset', {
 				customize_posts_update_changeset_nonce: component.data.customize_posts_update_changeset_nonce,
 				previewed_post: component.data.previewed_post,
@@ -96,7 +98,11 @@ var EditPostPreviewAdmin = (function( $ ) {
 			} );
 
 			request.fail( function( resp ) {
-				alert( resp ); // eslint-disable-line no-alert
+				var error = JSON.parse( resp.responseText ), errorText;
+				if ( error.data ) {
+					errorText = error.data.replace( /_/g, ' ' );
+					alert( errorText.charAt( 0 ).toUpperCase() + errorText.slice( 1 ) ); // eslint-disable-line no-alert
+				}
 			} );
 
 			request.done( function( resp ) {
@@ -107,7 +113,7 @@ var EditPostPreviewAdmin = (function( $ ) {
 
 			request.always( function() {
 				$btn.removeClass( 'disabled' );
-				component.previewButtonSpinner.removeClass( 'is-active' ).removeClass( 'is-active-preview' );
+				component.previewButtonSpinner.removeClass( 'is-active is-active-preview' );
 			} );
 		}
 	};

--- a/js/edit-post-preview-admin.js
+++ b/js/edit-post-preview-admin.js
@@ -15,7 +15,10 @@ var EditPostPreviewAdmin = (function( $ ) {
 	}
 
 	component.init = function() {
-		$( '#post-preview' )
+		component.previewButton = $( '#post-preview' );
+		component.previewButtonSpinner = $( 'span.spinner' ).first().clone();
+		component.previewButton.after( component.previewButtonSpinner );
+		component.previewButton
 			.off( 'click.post-preview' )
 			.on( 'click.post-preview', component.onClickPreviewBtn );
 	};
@@ -66,7 +69,6 @@ var EditPostPreviewAdmin = (function( $ ) {
 			post_excerpt: $( '#excerpt' ).val(),
 			comment_status: $( '#comment_status' ).prop( 'checked' ) ? 'open' : 'closed',
 			ping_status: $( '#ping_status' ).prop( 'checked' ) ? 'open' : 'closed',
-			post_status: $( '#post_status' ).val(),
 			post_author: parseInt( $( '#post_author_override' ).val(), 10 )
 		};
 		postSettingId = 'post[' + postType + '][' + postId + ']';
@@ -81,6 +83,8 @@ var EditPostPreviewAdmin = (function( $ ) {
 			wp.customize.Loader.open( component.data.customize_url );
 			component.bindChangesToCustomizer( postSettingId, editor );
 		} else {
+			$btn.addClass( 'disabled' );
+			component.previewButtonSpinner.addClass( 'is-active' );
 			request = wp.ajax.post( 'customize_posts_update_changeset', {
 				customize_posts_update_changeset_nonce: component.data.customize_posts_update_changeset_nonce,
 				previewed_post: component.data.previewed_post,
@@ -91,6 +95,11 @@ var EditPostPreviewAdmin = (function( $ ) {
 			request.done( function( resp ) {
 				wp.customize.Loader.open( resp.customize_url );
 				component.bindChangesToCustomizer( postSettingId, editor );
+			} );
+
+			request.always( function() {
+				$btn.removeClass( 'disabled' );
+				component.previewButtonSpinner.removeClass( 'is-active' );
 			} );
 		}
 
@@ -113,8 +122,7 @@ var EditPostPreviewAdmin = (function( $ ) {
 					editor.setContent( wp.editor.autop( data[ postSettingId ].post_content ) );
 				}
 
-				// @todo Handle post_date sync.
-				$( '#post_status' ).val( data[ postSettingId ].post_status );
+				// @todo Handle post_status and post_date sync.
 				$( '#content' ).val( data[ postSettingId ].post_content ).trigger( 'change' );
 				$( '#excerpt' ).val( data[ postSettingId ].post_excerpt ).trigger( 'change' );
 				$( '#comment_status' ).prop( 'checked', 'open' === data[ postSettingId ].comment_status ).trigger( 'change' );

--- a/js/edit-post-preview-customize.js
+++ b/js/edit-post-preview-customize.js
@@ -1,4 +1,4 @@
-/* global jQuery, _editPostPreviewCustomizeExports, JSON, console, wp */
+/* global jQuery, _editPostPreviewCustomizeExports, JSON, console, wp, _ */
 /* exported EditPostPreviewCustomize */
 var EditPostPreviewCustomize = (function( $, api ) {
 	'use strict';

--- a/js/edit-post-preview-customize.js
+++ b/js/edit-post-preview-customize.js
@@ -70,6 +70,8 @@ var EditPostPreviewCustomize = (function( $, api ) {
  		 */
 		if ( ! api.state.has( 'changesetStatus' ) ) {
 			api.previewer.bind( 'customized-posts', component.populateSettings );
+		} else {
+			component.extendPreviewerQuery();
 		}
 
 		// Prevent 'saved' state from becoming false, since we only want to save from the admin page.
@@ -120,6 +122,20 @@ var EditPostPreviewCustomize = (function( $, api ) {
 	 */
 	component.sendSettingsToEditPostScreen = function( settings ) {
 		component.parentFrame.send( 'customize-post-settings-data', settings );
+	};
+
+	component.extendPreviewerQuery = function() {
+		var originalQuery = api.previewer.query;
+
+		api.previewer.query = function() {
+			var retval = originalQuery.apply( this, arguments );
+
+			if ( component.data.previewed_post ) {
+				retval.customize_previewed_post_id = component.data.previewed_post.ID;
+			}
+
+			return retval;
+		};
 	};
 
 	/**

--- a/js/edit-post-preview-customize.js
+++ b/js/edit-post-preview-customize.js
@@ -1,4 +1,4 @@
-/* global jQuery, _editPostPreviewCustomizeExports, JSON, console */
+/* global jQuery, _editPostPreviewCustomizeExports, JSON, console, wp */
 /* exported EditPostPreviewCustomize */
 var EditPostPreviewCustomize = (function( $, api ) {
 	'use strict';
@@ -64,8 +64,13 @@ var EditPostPreviewCustomize = (function( $, api ) {
 	 */
 	component.ready = function() {
 
-		// Wait to populate the settings until the customized-posts message is received so we know the preview is ready to receive mesages.
-		api.previewer.bind( 'customized-posts', component.populateSettings );
+		/**
+		 * For backward compatibility.
+		 * Wait to populate the settings until the customized-posts message is received so we know the preview is ready to receive messages.
+ 		 */
+		if ( ! api.state.has( 'changesetStatus' ) ) {
+			api.previewer.bind( 'customized-posts', component.populateSettings );
+		}
 
 		// Prevent 'saved' state from becoming false, since we only want to save from the admin page.
 		api.state( 'saved' ).set( true ).validate = function() {

--- a/js/edit-post-preview-customize.js
+++ b/js/edit-post-preview-customize.js
@@ -70,8 +70,6 @@ var EditPostPreviewCustomize = (function( $, api ) {
  		 */
 		if ( ! api.state.has( 'changesetStatus' ) ) {
 			api.previewer.bind( 'customized-posts', component.populateSettings );
-		} else {
-			component.extendPreviewerQuery();
 		}
 
 		// Prevent 'saved' state from becoming false, since we only want to save from the admin page.
@@ -122,20 +120,6 @@ var EditPostPreviewCustomize = (function( $, api ) {
 	 */
 	component.sendSettingsToEditPostScreen = function( settings ) {
 		component.parentFrame.send( 'customize-post-settings-data', settings );
-	};
-
-	component.extendPreviewerQuery = function() {
-		var originalQuery = api.previewer.query;
-
-		api.previewer.query = function() {
-			var retval = originalQuery.apply( this, arguments );
-
-			if ( component.data.previewed_post ) {
-				retval.customize_previewed_post_id = component.data.previewed_post.ID;
-			}
-
-			return retval;
-		};
 	};
 
 	/**

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -408,6 +408,11 @@ class Customize_Posts_Plugin {
 		$src = plugins_url( 'css/edit-post-preview-customize' . $suffix, dirname( __FILE__ ) );
 		$deps = array( 'customize-controls' );
 		$wp_styles->add( $handle, $src, $deps, $this->version );
+
+		$handle = 'edit-post-preview-admin';
+		$src = plugins_url( 'css/edit-post-preview-admin' . $suffix, dirname( __FILE__ ) );
+		$deps = array( 'common' );
+		$wp_styles->add( $handle, $src, $deps, $this->version );
 	}
 
 	/**

--- a/php/class-edit-post-preview.php
+++ b/php/class-edit-post-preview.php
@@ -298,19 +298,14 @@ class Edit_Post_Preview {
 				return;
 			}
 			$setting->preview();
-			$params = $wp_customize_posts->get_setting_params( $setting );
-			$default_data = $params['value'];
-			$input_data = wp_array_slice_assoc( wp_unslash( $_POST['input_data'] ), array_keys( $default_data ) );
 
-			$params['value'] = array_merge(
-				$default_data,
-				$input_data
-			);
-			$input_customize_data[ $setting->id ] = $params;
-
+			$wp_customize->set_post_value( $setting->id, wp_array_slice_assoc(
+				array_merge( $setting->value(), wp_unslash( $_POST['input_data'] ) ),
+				array_keys( $setting->default )
+			) );
 			$response = $wp_customize->save_changeset_post( array(
 				'data' => $input_customize_data,
-			)  );
+			) );
 		}
 
 		wp_send_json_success( compact( 'customize_url', 'response' ) );

--- a/php/class-edit-post-preview.php
+++ b/php/class-edit-post-preview.php
@@ -39,6 +39,7 @@ class Edit_Post_Preview {
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue_customize_scripts' ) );
 		add_action( 'customize_preview_init', array( $this, 'make_auto_draft_status_previewable' ) );
 		add_action( 'customize_save_after', array( $this, 'remove_changeset_on_customize_publish' ) );
+		add_action( 'save_post', array( $this, 'remove_changeset_on_post_save' ), 10, 2 );
 		add_action( 'wp_ajax_' . self::UPDATE_CHANGESET_NONCE_ACTION, array( $this, 'update_post_changeset' ) );
 	}
 
@@ -307,6 +308,22 @@ class Edit_Post_Preview {
 		if ( ! empty( $_POST['customize_previewed_post_id'] ) ) {
 			$previewed_post_id = absint( wp_unslash( $_POST['customize_previewed_post_id'] ) );
 			delete_post_meta( $previewed_post_id, '_preview_changeset_uuid' );
+		}
+	}
+
+	/**
+	 * Removes _preview_changeset_uuid meta key when post is published.
+	 *
+	 * @param int     $post_id Post id.
+	 * @param WP_Post $post Post object.
+	 */
+	public function remove_changeset_on_post_save( $post_id, $post ) {
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
+		if ( 'publish' === $post->post_status ) {
+			delete_post_meta( $post_id, '_preview_changeset_uuid' );
 		}
 	}
 }

--- a/php/class-edit-post-preview.php
+++ b/php/class-edit-post-preview.php
@@ -125,7 +125,7 @@ class Edit_Post_Preview {
 	 * Enqueue scripts for post edit screen.
 	 */
 	public function enqueue_admin_scripts() {
-		if ( ! function_exists( 'get_current_screen' ) || ! get_current_screen() || 'post' !== get_current_screen()->base ) {
+		if ( ! function_exists( 'get_current_screen' ) || ! get_current_screen() || 'post' !== get_current_screen()->base || ! current_user_can( 'customize' ) ) {
 			return;
 		}
 		wp_enqueue_script( 'edit-post-preview-admin' );
@@ -214,7 +214,7 @@ class Edit_Post_Preview {
 			status_header( 400 );
 			wp_send_json_error( 'bad_nonce' );
 		} elseif ( ! current_user_can( 'customize' ) ) {
-			status_header( 403 ); // @todo If they don't have customize permission, show on front-end?
+			status_header( 403 );
 			wp_send_json_error( 'customize_not_allowed' );
 		} elseif ( empty( $_POST['previewed_post'] ) ) {
 			status_header( 400 );

--- a/php/class-edit-post-preview.php
+++ b/php/class-edit-post-preview.php
@@ -254,16 +254,20 @@ class Edit_Post_Preview {
 			) );
 			$changeset_post_id = $wp_customize->changeset_post_id();
 
-			if ( 'publish' === get_post_status( $changeset_post_id ) ) {
-				status_header( 400 );
-				wp_send_json_error( 'changeset_already_published' );
-			}
+			if ( $changeset_post_id ) {
+				if ( 'publish' === get_post_status( $changeset_post_id ) ) {
+					status_header( 400 );
+					wp_send_json_error( 'changeset_already_published' );
+				}
 
-			if ( ! current_user_can( get_post_type_object( 'customize_changeset' )->cap->edit_post, $changeset_post_id ) ) {
-				status_header( 403 );
-				wp_send_json_error( 'cannot_edit_changeset_post' );
+				if ( ! current_user_can( get_post_type_object( 'customize_changeset' )->cap->edit_post, $changeset_post_id ) ) {
+					status_header( 403 );
+					wp_send_json_error( 'cannot_edit_changeset_post' );
+				}
 			}
-		} else {
+		}
+
+		if ( empty( $changeset_post_id ) ) {
 			if ( ! current_user_can( get_post_type_object( 'customize_changeset' )->cap->create_posts ) ) {
 				status_header( 403 );
 				wp_send_json_error( 'cannot_create_changeset_post' );

--- a/php/class-edit-post-preview.php
+++ b/php/class-edit-post-preview.php
@@ -243,8 +243,8 @@ class Edit_Post_Preview {
 
 		$changeset_uuid = get_post_meta( $previewed_post_id, '_preview_changeset_uuid', true );
 
-		if ( empty( $wp_customize ) || ! ( $wp_customize instanceof WP_Customize_Manager ) || ! isset( $wp_customize->posts ) ) {
-			require_once( ABSPATH . WPINC . '/class-wp-customize-manager.php' );
+		if ( empty( $wp_customize ) || ! ( $wp_customize instanceof WP_Customize_Manager ) ) {
+			require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
 			require_once dirname( __FILE__ ) . '/class-wp-customize-posts.php';
 		}
 
@@ -277,6 +277,10 @@ class Edit_Post_Preview {
 			compact( 'changeset_uuid' ),
 			wp_unslash( $_POST['customize_url'] )
 		);
+
+		if ( ! isset( $wp_customize->posts ) || ! ( $wp_customize->posts instanceof WP_Customize_Posts ) ) {
+			wp_send_json_error( 'missing_posts_component' );
+		}
 
 		/**
 		 * Posts component.

--- a/php/class-edit-post-preview.php
+++ b/php/class-edit-post-preview.php
@@ -266,7 +266,12 @@ class Edit_Post_Preview {
 			wp_unslash( $_POST['customize_url'] )
 		);
 
-		$wp_customize_posts = new WP_Customize_Posts( $wp_customize );
+		/**
+		 * Posts component.
+		 *
+		 * @var WP_Customize_Posts $wp_customize_posts
+		 */
+		$wp_customize_posts = $wp_customize->posts;
 		$response = '';
 
 		if ( ! empty( $_POST['input_data'] ) ) {

--- a/php/class-edit-post-preview.php
+++ b/php/class-edit-post-preview.php
@@ -129,6 +129,7 @@ class Edit_Post_Preview {
 			return;
 		}
 		wp_enqueue_script( 'edit-post-preview-admin' );
+		wp_enqueue_style( 'edit-post-preview-admin' );
 		$post = $this->get_previewed_post();
 
 		$customize_url = add_query_arg(
@@ -306,6 +307,9 @@ class Edit_Post_Preview {
 			$response = $wp_customize->save_changeset_post( array(
 				'data' => $input_customize_data,
 			) );
+			if ( is_wp_error( $response ) ) {
+				wp_send_json_error( $response->get_error_code() );
+			}
 		}
 
 		wp_send_json_success( compact( 'customize_url', 'response' ) );

--- a/php/class-edit-post-preview.php
+++ b/php/class-edit-post-preview.php
@@ -38,7 +38,7 @@ class Edit_Post_Preview {
 		add_action( 'customize_controls_init', array( $this, 'remove_static_controls_and_sections' ), 100 );
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue_customize_scripts' ) );
 		add_action( 'customize_preview_init', array( $this, 'make_auto_draft_status_previewable' ) );
-		add_action( 'wp_ajax_' . self::UPDATE_CHANGESET_NONCE_ACTION, array( $this, 'update_changeset' ) );
+		add_action( 'wp_ajax_' . self::UPDATE_CHANGESET_NONCE_ACTION, array( $this, 'update_post_changeset' ) );
 	}
 
 	/**
@@ -209,7 +209,7 @@ class Edit_Post_Preview {
 	/**
 	 * Updates changeset via ajax when preview button is clicked.
 	 */
-	public function update_changeset() {
+	public function update_post_changeset() {
 		if ( ! check_ajax_referer( self::UPDATE_CHANGESET_NONCE_ACTION, self::UPDATE_CHANGESET_NONCE, false ) ) {
 			status_header( 400 );
 			wp_send_json_error( 'bad_nonce' );
@@ -254,7 +254,7 @@ class Edit_Post_Preview {
 		$wp_customize_posts = new WP_Customize_Posts( $wp_customize );
 		$response = '';
 
-		if ( ! empty( $_POST['customize_changeset_data'] ) ) {
+		if ( ! empty( $_POST['input_data'] ) ) {
 
 			$input_customize_data = array();
 			$settings = $wp_customize_posts->get_settings( array( $previewed_post_id ) );
@@ -264,7 +264,7 @@ class Edit_Post_Preview {
 				$setting->preview();
 				$params = $wp_customize_posts->get_setting_params( $setting );
 				$default_data = $params['value'];
-				$input_data = wp_array_slice_assoc( wp_unslash( $_POST['customize_changeset_data'] ), array_keys( $default_data ) );
+				$input_data = wp_array_slice_assoc( wp_unslash( $_POST['input_data'] ), array_keys( $default_data ) );
 
 				$params['value'] = array_merge(
 					$default_data,

--- a/php/class-edit-post-preview.php
+++ b/php/class-edit-post-preview.php
@@ -303,6 +303,8 @@ class Edit_Post_Preview {
 
 	/**
 	 * Removes _preview_changeset_uuid post meta key from after a changeset has been published.
+	 *
+	 * @todo Allow publishing the post from customizer.
 	 */
 	public function remove_changeset_on_customize_publish() {
 		if ( ! empty( $_POST['customize_previewed_post_id'] ) ) {

--- a/php/class-edit-post-preview.php
+++ b/php/class-edit-post-preview.php
@@ -270,9 +270,7 @@ class Edit_Post_Preview {
 		}
 
 		$customize_url = add_query_arg(
-			array(
-				'changeset_uuid' => $changeset_uuid,
-			),
+			compact( 'changeset_uuid' ),
 			wp_unslash( $_POST['customize_url'] )
 		);
 
@@ -315,9 +313,6 @@ class Edit_Post_Preview {
 			)  );
 		}
 
-		wp_send_json_success( array(
-			'customize_url' => $customize_url,
-			'response' => $response,
-		) );
+		wp_send_json_success( compact( 'customize_url', 'response' ) );
 	}
 }

--- a/php/class-edit-post-preview.php
+++ b/php/class-edit-post-preview.php
@@ -38,8 +38,6 @@ class Edit_Post_Preview {
 		add_action( 'customize_controls_init', array( $this, 'remove_static_controls_and_sections' ), 100 );
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue_customize_scripts' ) );
 		add_action( 'customize_preview_init', array( $this, 'make_auto_draft_status_previewable' ) );
-		add_action( 'customize_save_after', array( $this, 'remove_changeset_on_customize_publish' ) );
-		add_action( 'save_post', array( $this, 'remove_changeset_on_post_save' ), 10, 2 );
 		add_action( 'wp_ajax_' . self::UPDATE_CHANGESET_NONCE_ACTION, array( $this, 'update_post_changeset' ) );
 	}
 
@@ -299,33 +297,5 @@ class Edit_Post_Preview {
 			'customize_url' => $customize_url,
 			'response' => $response,
 		) );
-	}
-
-	/**
-	 * Removes _preview_changeset_uuid post meta key from after a changeset has been published.
-	 *
-	 * @todo Allow publishing the post from customizer.
-	 */
-	public function remove_changeset_on_customize_publish() {
-		if ( ! empty( $_POST['customize_previewed_post_id'] ) ) {
-			$previewed_post_id = absint( wp_unslash( $_POST['customize_previewed_post_id'] ) );
-			delete_post_meta( $previewed_post_id, '_preview_changeset_uuid' );
-		}
-	}
-
-	/**
-	 * Removes _preview_changeset_uuid meta key when post is published.
-	 *
-	 * @param int     $post_id Post id.
-	 * @param WP_Post $post Post object.
-	 */
-	public function remove_changeset_on_post_save( $post_id, $post ) {
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			return;
-		}
-
-		if ( 'publish' === $post->post_status ) {
-			delete_post_meta( $post_id, '_preview_changeset_uuid' );
-		}
 	}
 }

--- a/tests/php/test-ajax-class-wp-customize-posts.php
+++ b/tests/php/test-ajax-class-wp-customize-posts.php
@@ -463,6 +463,9 @@ class Test_Ajax_WP_Customize_Posts extends WP_Ajax_UnitTestCase {
 	 * @see Edit_Post_Preview::update_post_changeset()
 	 */
 	public function test_update_post_changeset_successes() {
+		if ( version_compare( strtok( get_bloginfo( 'version' ), '-' ), '4.7', '<' ) ) {
+			return;
+		}
 
 		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $user_id );

--- a/tests/php/test-ajax-class-wp-customize-posts.php
+++ b/tests/php/test-ajax-class-wp-customize-posts.php
@@ -457,4 +457,72 @@ class Test_Ajax_WP_Customize_Posts extends WP_Ajax_UnitTestCase {
 		$this->die_args = func_get_args();
 	}
 
+	/**
+	 * Test update_post_changeset() successes.
+	 *
+	 * @see Edit_Post_Preview::update_post_changeset()
+	 */
+	public function test_update_post_changeset_successes() {
+
+		$user_id = $this->factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $user_id );
+
+		$post_id = self::factory()->post->create( array(
+			'post_name' => 'Testing',
+			'post_content' => 'hello world'
+		) );
+
+		$input_data = array(
+			'post_title' => 'Testing New',
+			'post_name' => 'testing-new',
+			'post_parent' => '',
+			'menu_order' => '',
+			'post_content' => 'hello world new',
+			'post_excerpt' => 'Test excerpt',
+			'comment_status' => 'closed',
+			'ping_status' => 'closed',
+			'post_author' => $user_id,
+		);
+
+		$_POST = wp_slash( array(
+			'customize_posts_update_changeset_nonce' => wp_create_nonce( 'customize_posts_update_changeset' ),
+			'previewed_post' => $post_id,
+			'customize_url' => wp_customize_url(),
+			'input_data' => $input_data,
+		) );
+		$this->make_ajax_call( 'customize_posts_update_changeset' );
+		$response = json_decode( $this->_last_response, true );
+
+		$this->assertTrue( $response['success'] );
+		$this->assertArrayHasKey( 'customize_url', $response['data'] );
+		$this->assertArrayHasKey( 'response', $response['data'] );
+		$this->assertArrayHasKey( 'setting_validities', $response['data']['response'] );
+
+		$setting_key = "post[post][$post_id]";
+		$this->assertTrue( $response['data']['response']['setting_validities'][ $setting_key ] );
+
+		$customize_url_parts = parse_url( $response['data']['customize_url'] );
+		parse_str( $customize_url_parts['query'], $url_query );
+		$this->assertNotEmpty( $url_query['changeset_uuid'] );
+		$this->assertEquals( get_post_meta( $post_id, '_preview_changeset_uuid', true ), $url_query['changeset_uuid'] );
+
+		$query = new WP_Query( array(
+			'post_name' => $url_query['changeset_uuid'],
+			'post_type' => 'customize_changeset',
+			'post_status' => 'auto-draft',
+			'no_found_rows' => true,
+			'update_post_term_cache' => false,
+			'update_post_meta_cache' => false,
+			'posts_page_page' => 1,
+		) );
+
+		$post = array_shift( $query->posts );
+
+		$settings_data = json_decode( $post->post_content, true );
+
+		foreach( $settings_data as $key => $data ) {
+			$this->assertEquals( $setting_key, $key );
+			$this->assertArraySubset( $input_data, $data['value'] );
+		}
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/xwp/wp-customize-posts/issues/338