### PR TITLE
Stop continuous ajax requests in select2

### DIFF
--- a/js/customize-posts-panel.js
+++ b/js/customize-posts-panel.js
@@ -69,7 +69,10 @@
 						});
 						request.done( success );
 						request.fail( failure );
-					}
+
+						return request;
+					},
+					delay: 250
 				},
 				templateResult: function( data ) {
 					return panel.queriedPostSelect2ItemResultTemplate( data );


### PR DESCRIPTION
**Issue:** When we type to select a post in post-select-lookup select2 input , it sends continuous ajax requests for each letter we type without any delay. Ideally the previous request should cancel each time a new request is sent and there should be at least some delay. This PR fixes that issue.

Example of Issue:
![select2-issue](https://cloud.githubusercontent.com/assets/6297436/25166403/ebee88c8-24f8-11e7-9c56-da1590c2e796.gif)
