### PR TITLE
Release 0.8.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,38 @@
 sudo: false
 
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+cache:
+  directories:
+    - node_modules
+    - vendor
+    - $HOME/phpunit-bin
+
 language:
-    - php
-    - node_js
+  - php
+  - node_js
 
 php:
-    - 5.2
-    - 7.0
+  - 5.3
+  - 7.0
 
 env:
-    - WP_VERSION=4.5 WP_MULTISITE=1
-    - WP_VERSION=latest WP_MULTISITE=0
-    - WP_VERSION=trunk WP_MULTISITE=0
-    - WP_VERSION=trunk WP_MULTISITE=1
+  - WP_VERSION=trunk WP_MULTISITE=0
+  - WP_VERSION=latest WP_MULTISITE=0
+  - WP_VERSION=4.6.1 WP_MULTISITE=0
+  - WP_VERSION=latest WP_MULTISITE=1
 
 install:
-    - nvm install 4 && nvm use 4
-    - export DEV_LIB_PATH=dev-lib
-    - if [ ! -e "$DEV_LIB_PATH" ] && [ -L .travis.yml ]; then export DEV_LIB_PATH=$( dirname $( readlink .travis.yml ) ); fi
-    - if [ ! -e "$DEV_LIB_PATH" ]; then git clone https://github.com/xwp/wp-dev-lib.git $DEV_LIB_PATH; fi
-    - source $DEV_LIB_PATH/travis.install.sh
+  - nvm install 6 && nvm use 6
+  - export DEV_LIB_PATH=dev-lib
+  - if [ ! -e "$DEV_LIB_PATH" ] && [ -L .travis.yml ]; then export DEV_LIB_PATH=$( dirname $( readlink .travis.yml ) ); fi
+  - source $DEV_LIB_PATH/travis.install.sh
 
 script:
-    - source $DEV_LIB_PATH/travis.script.sh
+  - source $DEV_LIB_PATH/travis.script.sh
 
 after_script:
-    - source $DEV_LIB_PATH/travis.after_script.sh
+  - source $DEV_LIB_PATH/travis.after_script.sh

--- a/css/edit-post-preview-admin.css
+++ b/css/edit-post-preview-admin.css
@@ -1,0 +1,3 @@
+#preview-action .spinner:not(.is-active-preview) {
+	visibility: hidden !important;
+}

--- a/css/edit-post-preview-customize.css
+++ b/css/edit-post-preview-customize.css
@@ -3,7 +3,11 @@
 }
 
 #customize-header-actions #save,
-#customize-header-actions #snapshot-save {
+#customize-header-actions #snapshot-save,
+#snapshot-status-button-wrapper,
+#snapshot-preview-link,
+#snapshot-expand-button
+{
 	display: none !important;
 }
 

--- a/customize-posts.php
+++ b/customize-posts.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Customize Posts
- * Description: Manage posts and postmeta via the Customizer. Works best in conjunction with the <a href="https://wordpress.org/plugins/customize-setting-validation/">Customize Setting Validation</a> plugin.
+ * Description: Manage posts and postmeta via the Customizer.
  * Plugin URI: https://github.com/xwp/wp-customize-posts/
  * Version: 0.8.5
  * Author: XWP

--- a/js/customize-post-section.js
+++ b/js/customize-post-section.js
@@ -891,7 +891,8 @@
 
 			// Detect conflict errors.
 			api.bind( 'error', function( response ) {
-				var theirValue, ourValue;
+				var theirValue, ourValue,
+					conflictedControls = [];
 				if ( ! response.update_conflicted_setting_values ) {
 					return;
 				}
@@ -912,8 +913,22 @@
 						} );
 						control.notifications.remove( notification.code );
 						control.notifications.add( notification.code, notification );
+						conflictedControls.push( control );
 					}
 				} );
+
+				// Focus on first field that have conflict.
+				if ( section.expanded() ) {
+					_.every( section.controls(), function( _setting ) {
+						return _.every( conflictedControls, function( conflictedControl ) {
+							if ( conflictedControl.id === _setting.id ) {
+								_setting.focus();
+								return false;
+							}
+							return true;
+						} );
+					} );
+				}
 			} );
 
 			api.bind( 'save', function() {

--- a/js/customize-posts-panel.js
+++ b/js/customize-posts-panel.js
@@ -69,7 +69,10 @@
 						});
 						request.done( success );
 						request.fail( failure );
-					}
+
+						return request;
+					},
+					delay: 250
 				},
 				templateResult: function( data ) {
 					return panel.queriedPostSelect2ItemResultTemplate( data );

--- a/js/customize-posts.js
+++ b/js/customize-posts.js
@@ -395,7 +395,7 @@
 	 * @return {wp.customize.Section|null} Added (or existing) section, or null if not able to be added.
 	 */
 	component.addPostSection = function( settingId ) {
-		var section, parsedSettingId, sectionId, panelId, sectionType, Constructor, htmlParser, postTypeObj;
+		var section, parsedSettingId, sectionId, panelId, sectionType, Constructor, htmlParser, postTypeObj, customizeActionTpl;
 		parsedSettingId = component.parseSettingId( settingId );
 		if ( ! parsedSettingId || 'post' !== parsedSettingId.settingType ) {
 			throw new Error( 'Bad setting ID' );
@@ -422,7 +422,8 @@
 
 		Constructor = api.sectionConstructor[ sectionType ] || api.sectionConstructor.post;
 
-		htmlParser = $( '<div>' ).html( component.data.l10n.sectionCustomizeActionTpl.replace( '%s', api.panel( panelId ).params.title ) );
+		customizeActionTpl = postTypeObj.labels.customize_action || component.data.l10n.sectionCustomizeActionTpl;
+		htmlParser = $( '<div>' ).html( customizeActionTpl.replace( '%s', api.panel( panelId ).params.title ) );
 		section = new Constructor( sectionId, {
 			params: {
 				id: sectionId,

--- a/js/edit-post-preview-customize.js
+++ b/js/edit-post-preview-customize.js
@@ -1,4 +1,4 @@
-/* global jQuery, _editPostPreviewCustomizeExports, JSON, console */
+/* global jQuery, _editPostPreviewCustomizeExports, JSON, console, wp, _ */
 /* exported EditPostPreviewCustomize */
 var EditPostPreviewCustomize = (function( $, api ) {
 	'use strict';
@@ -64,8 +64,13 @@ var EditPostPreviewCustomize = (function( $, api ) {
 	 */
 	component.ready = function() {
 
-		// Wait to populate the settings until the customized-posts message is received so we know the preview is ready to receive mesages.
-		api.previewer.bind( 'customized-posts', component.populateSettings );
+		/**
+		 * For backward compatibility.
+		 * Wait to populate the settings until the customized-posts message is received so we know the preview is ready to receive messages.
+ 		 */
+		if ( ! api.state.has( 'changesetStatus' ) ) {
+			api.previewer.bind( 'customized-posts', component.populateSettings );
+		}
 
 		// Prevent 'saved' state from becoming false, since we only want to save from the admin page.
 		api.state( 'saved' ).set( true ).validate = function() {

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -408,6 +408,11 @@ class Customize_Posts_Plugin {
 		$src = plugins_url( 'css/edit-post-preview-customize' . $suffix, dirname( __FILE__ ) );
 		$deps = array( 'customize-controls' );
 		$wp_styles->add( $handle, $src, $deps, $this->version );
+
+		$handle = 'edit-post-preview-admin';
+		$src = plugins_url( 'css/edit-post-preview-admin' . $suffix, dirname( __FILE__ ) );
+		$deps = array( 'common' );
+		$wp_styles->add( $handle, $src, $deps, $this->version );
 	}
 
 	/**

--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -70,6 +70,7 @@ class Customize_Posts_Plugin {
 		add_filter( 'customize_loaded_components', array( $this, 'add_posts_to_customize_loaded_components' ), 0, 1 );
 		add_filter( 'customize_loaded_components', array( $this, 'filter_customize_loaded_components' ), 100, 2 );
 		add_action( 'customize_register', array( $this, 'load_support_classes' ) );
+		add_action( 'delete_post', array( $this, 'cleanup_autodraft_on_changeset_delete' ) );
 	}
 
 	/**
@@ -407,5 +408,40 @@ class Customize_Posts_Plugin {
 		$src = plugins_url( 'css/edit-post-preview-customize' . $suffix, dirname( __FILE__ ) );
 		$deps = array( 'customize-controls' );
 		$wp_styles->add( $handle, $src, $deps, $this->version );
+	}
+
+	/**
+	 * Delete auto-draft posts associated with the supplied changeset.
+	 *
+	 * @param int $post_id changeset/snapshot post_id.
+	 */
+	public function cleanup_autodraft_on_changeset_delete( $post_id ) {
+		global $wpdb;
+		$post = get_post( $post_id );
+		$allowed_snapshot_post_type = array( 'customize_changeset', 'customize_snapshot' );
+		if ( ! $post || ! in_array( $post->post_type, $allowed_snapshot_post_type, true ) ) {
+			return;
+		}
+		require_once( ABSPATH . WPINC . '/class-wp-customize-setting.php' );
+		require_once( dirname( __FILE__ ) . '/class-wp-customize-post-setting.php' );
+		$settings_data = json_decode( $post->post_content, true );
+		$status_to_delete = array( 'auto-draft', 'customize-draft' );
+		foreach ( $settings_data as $setting_key => $val ) {
+			if ( preg_match( WP_Customize_Post_Setting::SETTING_ID_PATTERN, $setting_key, $matches ) ) {
+				$setting_post = get_post( $matches['post_id'] );
+				if ( ! ( $setting_post instanceof WP_Post ) || ! in_array( $setting_post->post_status, $status_to_delete, true ) ) {
+					continue;
+				}
+
+				// Confirm that this changeset is the only one which references this post so it is cleared for garbage collection.
+				$query = $wpdb->prepare( "SELECT ID FROM $wpdb->posts WHERE post_type = %s AND ID != %d AND ", $post->post_type, $post->ID );
+				$query .= $wpdb->prepare( 'post_content LIKE %s', '%' . $wpdb->esc_like( wp_json_encode( $setting_key ) ) . '%' );
+				$query .= ' LIMIT 1';
+				if ( $wpdb->get_var( $query ) ) { // WPCS: unprepared SQL ok.
+					continue;
+				}
+				wp_delete_post( $setting_post->ID, true );
+			}
+		}
 	}
 }

--- a/php/class-edit-post-preview.php
+++ b/php/class-edit-post-preview.php
@@ -104,7 +104,7 @@ class Edit_Post_Preview {
 	public static function get_preview_post_link( $post ) {
 		$permalink = '';
 
-		if ( $post instanceof WP_Post ) {
+		if ( $post instanceof WP_Post && post_type_exists( $post->post_type ) ) {
 			$id_param = ( 'page' === $post->post_type ) ? 'page_id' : 'p';
 			$args = array();
 			$args['preview'] = true;

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -846,6 +846,7 @@ final class WP_Customize_Posts {
 						__( 'Customize Object Selector', 'customize-posts' )
 					)
 				),
+				'trashPostNotification' => __( 'This has been untrashed. If you publish changes now, its status will change to the selected status. Move back to trash to avoid this.' , 'customize-posts' ),
 
 				/* translators: %s post type */
 				'jumpToPostPlaceholder' => __( 'Jump to %s', 'customize-posts' ),
@@ -1380,6 +1381,7 @@ final class WP_Customize_Posts {
 		// Amend trashed post setting values with the pre-trashed state.
 		if ( $setting instanceof WP_Customize_Post_Setting && 'trash' === $setting_params['value']['post_status'] ) {
 			$setting_params['dirty'] = true;
+			$setting_params['trashedPreviously'] = true;
 
 			// Resurrect the old status.
 			$former_status = get_post_meta( $setting->post_id, '_wp_trash_meta_status', true );

--- a/tests/php/test-class-wp-customize-posts-preview.php
+++ b/tests/php/test-class-wp-customize-posts-preview.php
@@ -281,7 +281,6 @@ class Test_WP_Customize_Posts_Preview extends WP_UnitTestCase {
 	 * Test filter_the_posts_to_preview_settings().
 	 *
 	 * @covers WP_Customize_Posts_Preview::filter_the_posts_to_preview_settings()
-	 * @covers WP_Customize_Posts_Preview::compare_posts_to_resort_posts_for_query()
 	 */
 	public function test_filter_the_posts_to_preview_settings() {
 		$data = array(


### PR DESCRIPTION
- [x] Create new milestone for release. Move issues and PRs from Next Minor/Major Release into it. 
- [x] Bump version numbers. `ack -Q 0.8.5` and replace with `0.8.6` where appropriate (this needs to be automated)
- [x] [Draft new GitHub release tag](https://github.com/xwp/wp-customize-posts/releases/new?tag=0.8.6) `0.8.6` on `master`.
- [x] Add changelog to release notes.
- [x] Add contributor props to release notes.
- [x] Copy changelog and contributor props HTML to readme. 
- [x] Build ZIP via `grunt build; cd build; zip -r ../customize-posts-0.8.6.zip *; cd -`, and add link to readme in tag release notes: https://github.com/xwp/wp-customize-posts/blob/0.8.6/readme.md#changelog
- [x] Test build.
- [ ] Merge release PR.
- [ ] Deploy to WordPress.org via `grunt deploy`. Remember to look at SVN diff.
- [ ] Publish GitHub release.
- [ ] Close GitHub milestone.