### PR TITLE
Add fix for nested edit shortcuts in Twenty Seventeen front-page panels

### DIFF
--- a/php/theme-support/class-customize-posts-twenty-seventeen-support.php
+++ b/php/theme-support/class-customize-posts-twenty-seventeen-support.php
@@ -28,6 +28,7 @@ class Customize_Posts_Twenty_Seventeen_Support extends Customize_Posts_Theme_Sup
 	 */
 	public function add_support() {
 		add_filter( 'customize_posts_partial_schema', array( $this, 'filter_partial_schema' ) );
+		add_action( 'wp_head', array( $this, 'print_preview_style' ), 200 );
 	}
 
 	/**
@@ -41,5 +42,35 @@ class Customize_Posts_Twenty_Seventeen_Support extends Customize_Posts_Theme_Sup
 	public function filter_partial_schema( $schema ) {
 		$schema['post_excerpt']['fallback_refresh'] = false; // Not needed because there are no has_excerpt() checks in the theme.
 		return $schema;
+	}
+
+	/**
+	 * Print style for preview.
+	 *
+	 * Due to lack of child selector in `.twentyseventeen-panel .customize-partial-edit-shortcut button`.
+	 * This won't be needed once WP Core #41557 is merged.
+	 *
+	 * @link https://core.trac.wordpress.org/ticket/41557
+	 * @link https://github.com/WordPress/wordpress-develop/blob/4.7.0/src/wp-content/themes/twentyseventeen/style.css#L3043-L3047
+	 */
+	public function print_preview_style() {
+		if ( ! is_customize_preview() ) {
+			return;
+		}
+		?>
+		<style>
+		.widget .customize-partial-edit-shortcut button,
+		.customize-partial-edit-shortcut button {
+			left: -30px !important;
+			top: 2px !important;
+		}
+
+		/* Add some space around the visual edit shortcut buttons. */
+		.twentyseventeen-panel > .customize-partial-edit-shortcut > button {
+			top: 30px !important;
+			left: 30px !important;
+		}
+		</style>
+		<?php
 	}
 }


### PR DESCRIPTION
Before:

<img width="1123" alt="panel-nested-shortcut-mispositioned" src="https://user-images.githubusercontent.com/134745/28948338-e5c86cd8-7869-11e7-8457-20fa5b5a482a.png">

After:
<img width="1147" alt="panel-nested-shortcut-fixed" src="https://user-images.githubusercontent.com/134745/28948341-ecb1c9fe-7869-11e7-80b8-dc4e2431c3f4.png">

Patch upstreamed to theme in https://core.trac.wordpress.org/ticket/41557