### PR TITLE
Fix syncing of post changes made in post preview customizer back to edit post screen

### DIFF
--- a/php/class-customize-posts-plugin.php
+++ b/php/class-customize-posts-plugin.php
@@ -71,6 +71,12 @@ class Customize_Posts_Plugin {
 		add_filter( 'customize_loaded_components', array( $this, 'filter_customize_loaded_components' ), 100, 2 );
 		add_action( 'customize_register', array( $this, 'load_support_classes' ) );
 		add_action( 'delete_post', array( $this, 'cleanup_autodraft_on_changeset_delete' ) );
+
+		require_once dirname( __FILE__ ) . '/class-wp-customize-postmeta-controller.php';
+		require_once dirname( __FILE__ ) . '/class-wp-customize-page-template-controller.php';
+		require_once dirname( __FILE__ ) . '/class-wp-customize-featured-image-controller.php';
+		$this->page_template_controller = new WP_Customize_Page_Template_Controller();
+		$this->featured_image_controller = new WP_Customize_Featured_Image_Controller();
 	}
 
 	/**
@@ -170,12 +176,6 @@ class Customize_Posts_Plugin {
 		require_once dirname( __FILE__ ) . '/class-wp-customize-posts.php';
 		if ( in_array( 'posts', $components, true ) ) {
 			$wp_customize->posts = new WP_Customize_Posts( $wp_customize );
-
-			require_once dirname( __FILE__ ) . '/class-wp-customize-postmeta-controller.php';
-			require_once dirname( __FILE__ ) . '/class-wp-customize-page-template-controller.php';
-			require_once dirname( __FILE__ ) . '/class-wp-customize-featured-image-controller.php';
-			$this->page_template_controller = new WP_Customize_Page_Template_Controller();
-			$this->featured_image_controller = new WP_Customize_Featured_Image_Controller();
 		}
 
 		return $components;


### PR DESCRIPTION
This partially reverts #258.

The component can only be checked for being disabled when the Customizer is instantiated, but the postmeta controllers have to be instantiated outside the Customizer for integration with the edit post screen.

Fixes #359.