### PR TITLE
Fix saving of postmeta in scheduled changesets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "xwp/wp-customize-posts",
 	"description": "Manage posts and postmeta via the Customizer.",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"type": "wordpress-plugin",
 	"keywords": [ "customizer", "customize", "posts", "postmeta", "preview", "featured-image", "page-template" ],
 	"homepage": "https://github.com/xwp/wp-customize-posts/",

--- a/customize-posts.php
+++ b/customize-posts.php
@@ -3,7 +3,7 @@
  * Plugin Name: Customize Posts
  * Description: Manage posts and postmeta via the Customizer.
  * Plugin URI: https://github.com/xwp/wp-customize-posts/
- * Version: 0.9.0
+ * Version: 0.9.1
  * Author: XWP
  * Author URI: https://make.xwp.co/
  * License: GPLv2+

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/xwp/wp-customize-posts.git"
   },
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "GPL-2.0+",
   "private": true,
   "devDependencies": {

--- a/php/class-wp-customize-posts.php
+++ b/php/class-wp-customize-posts.php
@@ -94,6 +94,9 @@ final class WP_Customize_Posts {
 		add_action( 'customize_register', array( $this, 'register_constructs' ), 20 );
 		add_filter( 'map_meta_cap', array( $this, 'filter_map_meta_cap' ), 10, 4 );
 		add_action( 'init', array( $this, 'register_meta' ), 100 );
+		if ( did_action( 'init' ) ) {
+			$this->register_meta(); // The init action will have already done in WP-CLI or WP Cron.
+		}
 		add_filter( 'customize_dynamic_setting_args', array( $this, 'filter_customize_dynamic_setting_args' ), 10, 2 );
 		add_filter( 'customize_dynamic_setting_class', array( $this, 'filter_customize_dynamic_setting_class' ), 5, 3 );
 		add_filter( 'customize_sanitize_nav_menus_created_posts', array( $this, 'filter_out_nav_menus_created_posts_for_customized_posts' ), 20 );

--- a/readme.md
+++ b/readme.md
@@ -90,6 +90,9 @@ The following are listed in reverse chronological order. The first, more recent 
 
 ## Changelog ##
 
+### [0.9.1] - [2017-11-13] ###
+Fix saving of postmeta in scheduled changesets. See [#375](https://github.com/xwp/wp-customize-posts/pull/375).
+
 ### [0.9.0] - [2017-11-11] ###
 * Bump minimum required WP version to 4.7; update compatibility for 4.9. See [#371](https://github.com/xwp/wp-customize-posts/pull/371).
 * Update wrapper around `notifications.add` for new params accepted in 4.9. See [#369](https://github.com/xwp/wp-customize-posts/pull/369).

--- a/readme.txt
+++ b/readme.txt
@@ -67,6 +67,10 @@ The following are listed in reverse chronological order. The first, more recent 
 
 == Changelog ==
 
+= [0.9.1] - [2017-11-13] =
+
+Fix saving of postmeta in scheduled changesets. See [#375](https://github.com/xwp/wp-customize-posts/pull/375).
+
 = [0.9.0] - [2017-11-11] =
 
 * Bump minimum required WP version to 4.7; update compatibility for 4.9. See [#371](https://github.com/xwp/wp-customize-posts/pull/371).

--- a/tests/php/test-class-wp-customize-postmeta-controller.php
+++ b/tests/php/test-class-wp-customize-postmeta-controller.php
@@ -148,7 +148,6 @@ class Test_WP_Customize_Postmeta_Controller extends WP_UnitTestCase {
 		);
 		/** @var WP_Customize_Postmeta_Controller $stub */
 		$stub = $this->getMockForAbstractClass( 'WP_Customize_Postmeta_Controller', array( $args ) );
-		$this->assertEmpty( $this->wp_customize->posts->registered_post_meta );
 		$this->assertEquals( 0, $stub->register_meta( $this->wp_customize->posts ) );
 	}
 
@@ -167,7 +166,7 @@ class Test_WP_Customize_Postmeta_Controller extends WP_UnitTestCase {
 		);
 		/** @var WP_Customize_Postmeta_Controller $stub */
 		$stub = $this->getMockForAbstractClass( 'WP_Customize_Postmeta_Controller', array( $args ) );
-		$this->assertEmpty( $customize_posts->registered_post_meta );
+		$customize_posts->registered_post_meta = array();
 		$this->assertEquals( count( $args['post_types'] ), $stub->register_meta( $this->wp_customize->posts ) );
 		$this->assertEquals( 10, has_filter( "sanitize_post_meta_{$args['meta_key']}", array( $stub, 'sanitize_value' ) ) );
 		$this->assertArrayHasKey( 'post', $customize_posts->registered_post_meta );
@@ -191,6 +190,7 @@ class Test_WP_Customize_Postmeta_Controller extends WP_UnitTestCase {
 		);
 		/** @var WP_Customize_Postmeta_Controller $stub */
 		$stub = $this->getMockForAbstractClass( 'WP_Customize_Postmeta_Controller', array( $args ) );
+		$customize_posts->registered_post_meta = array();
 		$this->assertEquals( count( get_post_types_by_support( 'page-attributes' ) ), $stub->register_meta( $this->wp_customize->posts ) );
 		$this->assertEquals( 10, has_filter( "sanitize_post_meta_{$args['meta_key']}", array( $stub, 'sanitize_value' ) ) );
 		$this->assertArrayNotHasKey( 'post', $customize_posts->registered_post_meta );

--- a/tests/php/test-class-wp-customize-posts.php
+++ b/tests/php/test-class-wp-customize-posts.php
@@ -757,17 +757,18 @@ class Test_WP_Customize_Posts extends WP_UnitTestCase {
 		wp_trash_post( $trashed_post_id );
 
 		$settings_params = $this->posts->get_settings( array( $published_post_id, $trashed_post_id, $draft_page_id, $nav_menu_item_id ) );
-		$this->assertEqualSets(
-			array(
-				WP_Customize_Post_Setting::get_post_setting_id( get_post( $published_post_id ) ),
-				WP_Customize_Post_Setting::get_post_setting_id( get_post( $trashed_post_id ) ),
-				WP_Customize_Post_Setting::get_post_setting_id( get_post( $draft_page_id ) ),
-				sprintf( 'nav_menu_item[%s]', $nav_menu_item_id ),
-				WP_Customize_Postmeta_Setting::get_post_meta_setting_id( get_post( $published_post_id ), 'baz' ),
-				WP_Customize_Postmeta_Setting::get_post_meta_setting_id( get_post( $trashed_post_id ), 'baz' )
-			),
-			array_keys( $settings_params )
+		$actual_setting_ids = array_keys( $settings_params );
+		$expected_setting_ids = array(
+			WP_Customize_Post_Setting::get_post_setting_id( get_post( $published_post_id ) ),
+			WP_Customize_Post_Setting::get_post_setting_id( get_post( $trashed_post_id ) ),
+			WP_Customize_Post_Setting::get_post_setting_id( get_post( $draft_page_id ) ),
+			sprintf( 'nav_menu_item[%s]', $nav_menu_item_id ),
+			WP_Customize_Postmeta_Setting::get_post_meta_setting_id( get_post( $published_post_id ), 'baz' ),
+			WP_Customize_Postmeta_Setting::get_post_meta_setting_id( get_post( $trashed_post_id ), 'baz' )
 		);
+		foreach ( $expected_setting_ids as $expected_setting_id ) {
+			$this->assertContains( $expected_setting_id, $actual_setting_ids );
+		}
 	}
 
 	/**


### PR DESCRIPTION
When a scheduled changeset publishes via WP Cron, the Customizer will bootstrap after the `init` action. In the course of normal Customizer bootstrapping, it happens at the `plugins_loaded` action. Because postmeta currently is registered at the `init` action, this means that the postmeta will not get registered during WP Cron because the Customizer will bootstrap after `init`.

This is also a problem for changesets that get published via WP-CLI, since `init` also is done before `wp post update $changeset_post_id --post_status=publish`.

In the Customizer the way to reproduce the problem is:

1. Open Customizer
2. Open a post to edit.
3. Change the post title
4. Change the featured image
5. Schedule the changes to go live.
6. At the scheduled time, the post title change is published whereas the featured image change is not.