### PR TITLE
Add AMP support (experimental)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "xwp/wp-customize-posts",
 	"description": "Manage posts and postmeta via the Customizer.",
-	"version": "0.9.1",
+	"version": "0.9.2",
 	"type": "wordpress-plugin",
 	"keywords": [ "customizer", "customize", "posts", "postmeta", "preview", "featured-image", "page-template" ],
 	"homepage": "https://github.com/xwp/wp-customize-posts/",

--- a/css/edit-post-preview-admin.css
+++ b/css/edit-post-preview-admin.css
@@ -1,3 +1,3 @@
-#preview-action .spinner:not(.is-active-preview) {
-	visibility: hidden !important;
+#preview-action .button.loading {
+	cursor: progress;
 }

--- a/customize-posts.php
+++ b/customize-posts.php
@@ -3,7 +3,7 @@
  * Plugin Name: Customize Posts
  * Description: Manage posts and postmeta via the Customizer.
  * Plugin URI: https://github.com/xwp/wp-customize-posts/
- * Version: 0.9.1
+ * Version: 0.9.2-alpha
  * Author: XWP
  * Author URI: https://make.xwp.co/
  * License: GPLv2+

--- a/js/customize-preview-posts.js
+++ b/js/customize-preview-posts.js
@@ -129,7 +129,9 @@
 					selectorBases.push( 'body.postid-' + String( postId ) );
 				}
 				schema.params.selector = _.map( selectorBases, function( selectorBase ) {
-					var selector = selectorBase + ' ' + schema.params.selector;
+					var selector = schema.params.selector.split( /,/ ).map( function( subSelector ) {
+						return selectorBase + ' ' + subSelector;
+					} ).join( ',' );
 					selector = selector.replace( /%d/g, String( postId ) );
 					return selector;
 				} ).join( ', ' );

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/xwp/wp-customize-posts.git"
   },
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "GPL-2.0+",
   "private": true,
   "devDependencies": {

--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -103,10 +103,12 @@ final class WP_Customize_Posts_Preview {
 		remove_filter( 'get_edit_post_link', '__return_empty_string' ); // See <https://core.trac.wordpress.org/ticket/38648>.
 
 		// Support for AMP.
-		add_action( 'amp_customizer_enqueue_preview_scripts', array( $this, 'enqueue_scripts' ) );
-		add_action( 'amp_customizer_enqueue_preview_scripts', array( $this, 'export_preview_data' ) );
-		add_filter( 'amp_post_template_data', array( $this, 'filter_amp_post_template_data' ), 10, 2 );
-		add_filter( 'customize_partial_render', array( $this, 'sanitize_amp_rendered_content_partial' ), 10, 3 );
+		if ( defined( 'AMP__VERSION' ) && version_compare( strtok( AMP__VERSION, '-' ), '0.6', '>=' ) ) {
+			add_action( 'amp_customizer_enqueue_preview_scripts', array( $this, 'enqueue_scripts' ) );
+			add_action( 'amp_customizer_enqueue_preview_scripts', array( $this, 'export_preview_data' ) );
+			add_filter( 'amp_post_template_data', array( $this, 'filter_amp_post_template_data' ), 10, 2 );
+			add_filter( 'customize_partial_render', array( $this, 'sanitize_amp_rendered_content_partial' ), 10, 3 );
+		}
 	}
 
 	/**

--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -166,9 +166,9 @@ final class WP_Customize_Posts_Preview {
 			&&
 			function_exists( 'amp_load_classes' )
 			&&
-			defined( 'AMP_QUERY_VAR' )
+			function_exists( 'is_amp_endpoint' )
 			&&
-			false !== get_query_var( AMP_QUERY_VAR, false )
+			is_amp_endpoint()
 		);
 		if ( $should_get_amp_content ) {
 			$post = get_post( $partial->post_id );

--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -104,9 +104,7 @@ final class WP_Customize_Posts_Preview {
 
 		// Support for AMP.
 		add_action( 'amp_customizer_enqueue_preview_scripts', array( $this, 'enqueue_scripts' ) );
-		if ( false === has_action( 'amp_post_template_footer', array( $this->component->manager->selective_refresh, 'export_preview_data' ) ) ) {
-			add_action( 'amp_post_template_footer', array( $this->component->manager->selective_refresh, 'export_preview_data' ) );
-		}
+		add_action( 'amp_customizer_enqueue_preview_scripts', array( $this, 'export_preview_data' ) );
 		add_filter( 'amp_post_template_data', array( $this, 'filter_amp_post_template_data' ), 10, 2 );
 		add_filter( 'customize_partial_render', array( $this, 'sanitize_amp_rendered_content_partial' ), 10, 3 );
 	}
@@ -164,16 +162,12 @@ final class WP_Customize_Posts_Preview {
 			&&
 			'post_content' === $partial->field_id
 			&&
-			function_exists( 'amp_load_classes' )
-			&&
 			function_exists( 'is_amp_endpoint' )
 			&&
 			is_amp_endpoint()
 		);
 		if ( $should_get_amp_content ) {
 			$post = get_post( $partial->post_id );
-
-			amp_load_classes();
 
 			// The following is copied from  AMP_Post_Template::__construct(). See <https://github.com/Automattic/amp-wp/blob/c73f4794b35e410c5c9cb4930c2514575d1bb741/includes/class-amp-post-template.php#L47-L51>.
 			$content_max_width = AMP_Post_Template::CONTENT_MAX_WIDTH;

--- a/php/class-wp-customize-posts-preview.php
+++ b/php/class-wp-customize-posts-preview.php
@@ -101,6 +101,14 @@ final class WP_Customize_Posts_Preview {
 		add_filter( 'customize_render_partials_response', array( $this, 'amend_with_queried_post_ids' ) );
 		add_filter( 'customize_render_partials_response', array( $this, 'amend_partials_response_with_rest_resources' ), 10, 3 );
 		remove_filter( 'get_edit_post_link', '__return_empty_string' ); // See <https://core.trac.wordpress.org/ticket/38648>.
+
+		// Support for AMP.
+		add_action( 'amp_customizer_enqueue_preview_scripts', array( $this, 'enqueue_scripts' ) );
+		if ( false === has_action( 'amp_post_template_footer', array( $this->component->manager->selective_refresh, 'export_preview_data' ) ) ) {
+			add_action( 'amp_post_template_footer', array( $this->component->manager->selective_refresh, 'export_preview_data' ) );
+		}
+		add_filter( 'amp_post_template_data', array( $this, 'filter_amp_post_template_data' ), 10, 2 );
+		add_filter( 'customize_partial_render', array( $this, 'sanitize_amp_rendered_content_partial' ), 10, 3 );
 	}
 
 	/**
@@ -124,6 +132,106 @@ final class WP_Customize_Posts_Preview {
 		add_filter( 'get_post_status', array( $this, 'filter_get_post_status' ), 10, 2 );
 		$this->has_preview_filters = true;
 		return true;
+	}
+
+	/**
+	 * Filter AMP post template data to add body classes.
+	 *
+	 * @param array   $data Data.
+	 * @param WP_Post $post Post.
+	 *
+	 * @return array Data.
+	 */
+	public function filter_amp_post_template_data( $data, $post ) {
+		if ( 'page' === $post->post_type ) {
+			$data['body_class'] .= sprintf( 'page-id-%d', $post->ID );
+		} else {
+			$data['body_class'] .= sprintf( 'postid-%d', $post->ID );
+		}
+		return $data;
+	}
+
+	/**
+	 * Sanitize rendered content field partial for AMP.
+	 *
+	 * @param string|array|false   $rendered The partial value. Default false.
+	 * @param WP_Customize_Partial $partial  WP_Customize_Setting instance.
+	 * @return string Rendered partial.
+	 */
+	public function sanitize_amp_rendered_content_partial( $rendered, $partial ) {
+		$should_get_amp_content = (
+			$partial instanceof WP_Customize_Post_Field_Partial
+			&&
+			'post_content' === $partial->field_id
+			&&
+			function_exists( 'amp_load_classes' )
+			&&
+			defined( 'AMP_QUERY_VAR' )
+			&&
+			false !== get_query_var( AMP_QUERY_VAR, false )
+		);
+		if ( $should_get_amp_content ) {
+			$post = get_post( $partial->post_id );
+
+			amp_load_classes();
+
+			// The following is copied from  AMP_Post_Template::__construct(). See <https://github.com/Automattic/amp-wp/blob/c73f4794b35e410c5c9cb4930c2514575d1bb741/includes/class-amp-post-template.php#L47-L51>.
+			$content_max_width = AMP_Post_Template::CONTENT_MAX_WIDTH;
+			if ( isset( $GLOBALS['content_width'] ) && $GLOBALS['content_width'] > 0 ) {
+				$content_max_width = $GLOBALS['content_width'];
+			}
+			$content_max_width = apply_filters( 'amp_content_max_width', $content_max_width );
+
+			// The following is adapted from AMP_Post_Template::build_post_content(). See <https://github.com/Automattic/amp-wp/blob/c73f4794b35e410c5c9cb4930c2514575d1bb741/includes/class-amp-post-template.php#L231-L265>.
+			$amp_content = new AMP_Content( $rendered,
+				apply_filters(
+					'amp_content_embed_handlers', array(
+						'AMP_Twitter_Embed_Handler' => array(),
+						'AMP_YouTube_Embed_Handler' => array(),
+						'AMP_DailyMotion_Embed_Handler' => array(),
+						'AMP_Vimeo_Embed_Handler' => array(),
+						'AMP_SoundCloud_Embed_Handler' => array(),
+						'AMP_Instagram_Embed_Handler' => array(),
+						'AMP_Vine_Embed_Handler' => array(),
+						'AMP_Facebook_Embed_Handler' => array(),
+						'AMP_Pinterest_Embed_Handler' => array(),
+						'AMP_Gallery_Embed_Handler' => array(),
+					),
+					$post
+				),
+				apply_filters(
+					'amp_content_sanitizers', array(
+						'AMP_Style_Sanitizer' => array(),
+						'AMP_Img_Sanitizer' => array(),
+						'AMP_Video_Sanitizer' => array(),
+						'AMP_Audio_Sanitizer' => array(),
+						'AMP_Playbuzz_Sanitizer' => array(),
+						'AMP_Iframe_Sanitizer' => array(
+							'add_placeholder' => true,
+						),
+						'AMP_Tag_And_Attribute_Sanitizer' => array(),
+					),
+					$post
+				),
+				array(
+					'content_max_width' => $content_max_width,
+				)
+			);
+			$rendered = $amp_content->get_amp_content();
+			foreach ( $amp_content->get_amp_scripts() as $id => $src ) {
+				$rendered .= sprintf( '<script async custom-element="%s" src="%s"></script>', esc_attr( $id ), esc_url( $src ) );
+			}
+			$styles = $amp_content->get_amp_styles();
+			if ( ! empty( $styles ) ) {
+				$rendered .= '<style>';
+				foreach ( $styles as $selector => $declarations ) {
+					$declarations = implode( ';', $declarations ) . ';';
+					$rendered .= sprintf( '%1$s{%2$s}', $selector, $declarations );
+				}
+				$rendered .= '</style>';
+			}
+		}
+		return $rendered;
 	}
 
 	/**
@@ -1310,7 +1418,7 @@ final class WP_Customize_Posts_Preview {
 	public function get_post_field_partial_schema( $field_id = '' ) {
 		$schema = array(
 			'post_title' => array(
-				'selector' => '.entry-title',
+				'selector' => '.entry-title, .amp-wp-title',
 			),
 			'post_name' => array(
 				'fallback_refresh' => false,
@@ -1329,7 +1437,7 @@ final class WP_Customize_Posts_Preview {
 				'fallback_refresh' => false,
 			),
 			'post_content' => array(
-				'selector' => '.entry-content',
+				'selector' => '.entry-content, .amp-wp-article-content',
 			),
 			'post_excerpt' => array(
 				'selector' => '.entry-summary',

--- a/tests/php/test-ajax-class-wp-customize-posts.php
+++ b/tests/php/test-ajax-class-wp-customize-posts.php
@@ -490,27 +490,21 @@ class Test_Ajax_WP_Customize_Posts extends WP_Ajax_UnitTestCase {
 		$_POST = wp_slash( array(
 			'customize_posts_update_changeset_nonce' => wp_create_nonce( 'customize_posts_update_changeset' ),
 			'previewed_post' => $post_id,
-			'customize_url' => wp_customize_url(),
 			'input_data' => $input_data,
 		) );
 		$this->make_ajax_call( 'customize_posts_update_changeset' );
 		$response = json_decode( $this->_last_response, true );
 
 		$this->assertTrue( $response['success'] );
-		$this->assertArrayHasKey( 'customize_url', $response['data'] );
+		$this->assertArrayHasKey( 'changeset_uuid', $response['data'] );
 		$this->assertArrayHasKey( 'response', $response['data'] );
 		$this->assertArrayHasKey( 'setting_validities', $response['data']['response'] );
 
 		$setting_key = "post[post][$post_id]";
 		$this->assertTrue( $response['data']['response']['setting_validities'][ $setting_key ] );
 
-		$customize_url_parts = parse_url( $response['data']['customize_url'] );
-		parse_str( $customize_url_parts['query'], $url_query );
-		$this->assertNotEmpty( $url_query['changeset_uuid'] );
-		$this->assertEquals( get_post_meta( $post_id, '_preview_changeset_uuid', true ), $url_query['changeset_uuid'] );
-
 		$query = new WP_Query( array(
-			'post_name' => $url_query['changeset_uuid'],
+			'post_name' => $response['data']['changeset_uuid'],
 			'post_type' => 'customize_changeset',
 			'post_status' => 'auto-draft',
 			'no_found_rows' => true,


### PR DESCRIPTION
* Open Customizer preview with AMP when clicking on AMP preview button from https://github.com/Automattic/amp-wp/pull/813: ![image](https://user-images.githubusercontent.com/134745/33699479-3ecb45c4-dac8-11e7-8bb4-f2d3f70f9202.png)
* Add support for previewing changes to post title and content via selective refresh in Customizer preview.
* Remove dead code no longer needed since minimum version of WP supported is 4.7.